### PR TITLE
[Old PR libui##507] Fix table editing redraw code on all platforms. 

### DIFF
--- a/common/tablemodel.c
+++ b/common/tablemodel.c
@@ -42,12 +42,6 @@ void uiprivTableModelSetCellValue(uiTableModel *m, int row, int column, const ui
 	mh = uiprivTableModelHandler(m);
 	(*(mh->SetCellValue))(mh, m, row, column, value);
 
-	// Abort redraw for button columns which signal being clicked
-	// by setting NULL.
-	// TODO check if NULL is never a valid value otherwise
-	if (value == NULL)
-		return;
-
 	uiTableModelRowChanged(m, row);
 }
 

--- a/common/tablemodel.c
+++ b/common/tablemodel.c
@@ -41,6 +41,14 @@ void uiprivTableModelSetCellValue(uiTableModel *m, int row, int column, const ui
 
 	mh = uiprivTableModelHandler(m);
 	(*(mh->SetCellValue))(mh, m, row, column, value);
+
+	// Abort redraw for button columns which signal being clicked
+	// by setting NULL.
+	// TODO check if NULL is never a valid value otherwise
+	if (value == NULL)
+		return;
+
+	uiTableModelRowChanged(m, row);
 }
 
 const uiTableTextColumnOptionalParams uiprivDefaultTextColumnOptionalParams = {

--- a/darwin/tablecolumn.m
+++ b/darwin/tablecolumn.m
@@ -292,9 +292,6 @@ struct textColumnCreateParams {
 	value = uiNewTableValueString([[self->tf stringValue] UTF8String]);
 	uiprivTableModelSetCellValue(self->m, row, self->textModelColumn, value);
 	uiFreeTableValue(value);
-	// always refresh the value in case the model rejected it
-	// TODO document that we do this, but not for the whole row (or decide to do both, or do neither...)
-	[self uiprivUpdate:row];
 }
 
 - (IBAction)uiprivOnCheckboxAction:(id)sender
@@ -306,8 +303,6 @@ struct textColumnCreateParams {
 	value = uiNewTableValueInt([self->cb state] != NSOffState);
 	uiprivTableModelSetCellValue(self->m, row, self->checkboxModelColumn, value);
 	uiFreeTableValue(value);
-	// always refresh the value in case the model rejected it
-	[self uiprivUpdate:row];
 }
 
 @end
@@ -539,8 +534,6 @@ struct textColumnCreateParams {
 
 	row = [self->t->tv rowForView:self->b];
 	uiprivTableModelSetCellValue(self->m, row, self->modelColumn, NULL);
-	// TODO document we DON'T update the cell after doing this
-	// TODO or decide what to do instead
 }
 
 @end

--- a/windows/tableediting.cpp
+++ b/windows/tableediting.cpp
@@ -168,11 +168,6 @@ HRESULT uiprivTableFinishEditingText(uiTable *t)
 	p = (*(t->columns))[t->editedSubitem];
 	uiprivTableModelSetCellValue(t->model, t->editedItem, p->textModelColumn, value);
 	uiFreeTableValue(value);
-	// always refresh the value in case the model rejected it
-	if (SendMessageW(t->hwnd, LVM_UPDATE, (WPARAM) (t->editedItem), 0) == (LRESULT) (-1)) {
-		logLastError(L"LVM_UPDATE");
-		return E_FAIL;
-	}
 	return uiprivTableAbortEditingText(t);
 }
 
@@ -250,11 +245,6 @@ HRESULT uiprivTableHandleNM_CLICK(uiTable *t, NMITEMACTIVATE *nm, LRESULT *lResu
 		uiFreeTableValue(value);
 	} else
 		uiprivTableModelSetCellValue(t->model, ht.iItem, modelColumn, NULL);
-	// always refresh the value in case the model rejected it
-	if (SendMessageW(t->hwnd, LVM_UPDATE, (WPARAM) (ht.iItem), 0) == (LRESULT) (-1)) {
-		logLastError(L"LVM_UPDATE");
-		return E_FAIL;
-	}
 
 done:
 	*lResult = 0;


### PR DESCRIPTION
Pretty much all information in the commit message. No
uiTableModelRowChanged was emitted on any of the changes when
editing cells in uiTable:

This fixes bugs on all platforms not calling uiTableModelRowChanged()
when setting a new value in edit mode. This is now automatically
done in uiprivTableModelSetValue() so that ALL uiTable views are
informed about the update.

Darwin and windows did some custom redrawing which hid this bug.
Unix does frequent unrelated redraw which hide the bug. It can often
be experienced when double clicking a checkbox.