### PR TITLE
[Old PR libui#509] darwin: Fix uiTable checkbox value not calling SetCellValue().

### DIFF
--- a/darwin/tablecolumn.m
+++ b/darwin/tablecolumn.m
@@ -181,6 +181,8 @@ struct textColumnCreateParams {
 			[self->cb setTransparent:NO];
 			uiDarwinSetControlFont(self->cb, NSRegularControlSize);
 			[self->cb setTranslatesAutoresizingMaskIntoConstraints:NO];
+			[self->cb setTarget:self];
+			[self->cb setAction:@selector(uiprivOnCheckboxAction:)];
 			[self addSubview:self->cb];
 
 			if (self->tf != nil) {


### PR DESCRIPTION
This is something that came up while trying things out with the new tester for uiTable suggested in #18:

The SetCellValue() when clicking a checkbox within a uiTable is never called.
The UI happiliy updates suggesting the value has been set - which is not actually the case.

The checkbox not redrawing with the actual check box value from the model is another related issue, see #17.

This has seemingly been reported upstream in various places too, e.g. [andlabs/ui#357](https://github.com/andlabs/ui/issues/357)