### PR TITLE
[Old PR libui#513] Add new API functions for table header clicks and sort indicators.

### DIFF
--- a/darwin/table.h
+++ b/darwin/table.h
@@ -16,6 +16,8 @@ struct uiTable {
 	uiprivScrollViewData *d;
 	int backgroundColumn;
 	uiTableModel *m;
+	void (*headerOnClicked)(uiTable *, int, void *);
+	void *headerOnClickedData;
 };
 
 // tablecolumn.m

--- a/darwin/table.m
+++ b/darwin/table.m
@@ -16,6 +16,7 @@
 	uiTableModel *uiprivM;
 }
 - (id)initWithFrame:(NSRect)r uiprivT:(uiTable *)t uiprivM:(uiTableModel *)m;
+- (uiTable *)uiTable;
 @end
 
 @implementation uiprivTableView
@@ -28,6 +29,11 @@
 		self->uiprivM = m;
 	}
 	return self;
+}
+
+- (uiTable *)uiTable
+{
+	return self->uiprivT;
 }
 
 // TODO is this correct for overflow scrolling?
@@ -86,6 +92,12 @@ static void setBackgroundColor(uiprivTableView *t, NSTableRowView *rv, NSInteger
 - (void)tableView:(NSTableView *)tv didAddRowView:(NSTableRowView *)rv forRow:(NSInteger)row
 {
 	setBackgroundColor((uiprivTableView *) tv, rv, row);
+}
+
+- (void)tableView:(uiprivTableView *)tv didClickTableColumn:(NSTableColumn *) tc
+{
+	uiTable *t = [tv uiTable];
+	t->headerOnClicked(t, [[tc identifier] intValue], t->headerOnClickedData);
 }
 
 @end
@@ -170,6 +182,17 @@ static void uiTableDestroy(uiControl *c)
 	uiFreeControl(uiControl(t));
 }
 
+void uiTableHeaderOnClicked(uiTable *t, void (*f)(uiTable *, int, void *), void *data)
+{
+	t->headerOnClicked = f;
+	t->headerOnClickedData = data;
+}
+
+static void defaultHeaderOnClicked(uiTable *table, int column, void *data)
+{
+	// do nothing
+}
+
 uiTable *uiNewTable(uiTableParams *p)
 {
 	uiTable *t;
@@ -209,10 +232,36 @@ uiTable *uiNewTable(uiTableParams *p)
 	sp.VScroll = YES;
 	t->sv = uiprivMkScrollView(&sp, &(t->d));
 
+	uiTableHeaderOnClicked(t, defaultHeaderOnClicked, NULL);
+
 	// TODO WHY DOES THIS REMOVE ALL GRAPHICAL GLITCHES?
 	// I got the idea from http://jwilling.com/blog/optimized-nstableview-scrolling/ but that was on an unrelated problem I didn't seem to have (although I have small-ish tables to start with)
 	// I don't get layer-backing... am I supposed to layer-back EVERYTHING manually? I need to check Interface Builder again...
 	[t->sv setWantsLayer:YES];
 
 	return t;
+}
+
+uiSortIndicator uiTableHeaderSortIndicator(uiTable *t, int lcol)
+{
+	NSTableColumn *tc = [t->tv tableColumnWithIdentifier:[@(lcol) stringValue]];
+	NSString *si = [[t->tv indicatorImageInTableColumn:tc] name];
+	if ([si isEqualToString:@"NSAscendingSortIndicator"])
+		return uiSortIndicatorAscending;
+	else if ([si isEqualToString:@"NSDescendingSortIndicator"])
+		return uiSortIndicatorDescending;
+	return uiSortIndicatorNone;
+}
+
+void uiTableHeaderSetSortIndicator(uiTable *t, int lcol, uiSortIndicator indicator)
+{
+	NSTableColumn *tc = [t->tv tableColumnWithIdentifier:[@(lcol) stringValue]];
+	NSImage *img;
+	if (indicator == uiSortIndicatorAscending)
+		img = [NSImage imageNamed:@"NSAscendingSortIndicator"];
+	else if (indicator == uiSortIndicatorDescending)
+		img = [NSImage imageNamed:@"NSDescendingSortIndicator"];
+	else
+		img = nil;
+	[t->tv setIndicatorImage:img inTableColumn:tc];
 }

--- a/darwin/tablecolumn.m
+++ b/darwin/tablecolumn.m
@@ -584,6 +584,7 @@ void uiTableAppendTextColumn(uiTable *t, const char *name, int textModelColumn, 
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -597,8 +598,9 @@ void uiTableAppendTextColumn(uiTable *t, const char *name, int textModelColumn, 
 	else
 		p.textParams = uiprivDefaultTextColumnOptionalParams;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -608,6 +610,7 @@ void uiTableAppendImageColumn(uiTable *t, const char *name, int imageModelColumn
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -616,8 +619,9 @@ void uiTableAppendImageColumn(uiTable *t, const char *name, int imageModelColumn
 	p.makeImageView = YES;
 	p.imageModelColumn = imageModelColumn;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -627,6 +631,7 @@ void uiTableAppendImageTextColumn(uiTable *t, const char *name, int imageModelCo
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -643,8 +648,9 @@ void uiTableAppendImageTextColumn(uiTable *t, const char *name, int imageModelCo
 	p.makeImageView = YES;
 	p.imageModelColumn = imageModelColumn;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -654,6 +660,7 @@ void uiTableAppendCheckboxColumn(uiTable *t, const char *name, int checkboxModel
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -663,8 +670,9 @@ void uiTableAppendCheckboxColumn(uiTable *t, const char *name, int checkboxModel
 	p.checkboxModelColumn = checkboxModelColumn;
 	p.checkboxEditableModelColumn = checkboxEditableModelColumn;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -674,6 +682,7 @@ void uiTableAppendCheckboxTextColumn(uiTable *t, const char *name, int checkboxM
 	struct textColumnCreateParams p;
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
 	memset(&p, 0, sizeof (struct textColumnCreateParams));
 	p.t = t;
@@ -691,8 +700,9 @@ void uiTableAppendCheckboxTextColumn(uiTable *t, const char *name, int checkboxM
 	p.checkboxModelColumn = checkboxModelColumn;
 	p.checkboxEditableModelColumn = checkboxEditableModelColumn;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:str params:&p];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -701,9 +711,11 @@ void uiTableAppendProgressBarColumn(uiTable *t, const char *name, int progressMo
 {
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivProgressBarTableColumn alloc] initWithIdentifier:ident table:t model:t->m modelColumn:progressModelColumn];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivProgressBarTableColumn alloc] initWithIdentifier:str table:t model:t->m modelColumn:progressModelColumn];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }
@@ -712,9 +724,11 @@ void uiTableAppendButtonColumn(uiTable *t, const char *name, int buttonModelColu
 {
 	uiprivTableColumn *col;
 	NSString *str;
+	NSString *ident;
 
+	ident = [@([[t->tv tableColumns] count]) stringValue];
+	col = [[uiprivButtonTableColumn alloc] initWithIdentifier:ident table:t model:t->m modelColumn:buttonModelColumn editableColumn:buttonClickableModelColumn];
 	str = [NSString stringWithUTF8String:name];
-	col = [[uiprivButtonTableColumn alloc] initWithIdentifier:str table:t model:t->m modelColumn:buttonModelColumn editableColumn:buttonClickableModelColumn];
 	[col setTitle:str];
 	[t->tv addTableColumn:col];
 }

--- a/test/page16.c
+++ b/test/page16.c
@@ -100,6 +100,21 @@ static void modelSetCellValue(uiTableModelHandler *mh, uiTableModel *m, int row,
 
 static uiTableModel *m;
 
+static void headerOnClicked(uiTable *t, int col, void *data)
+{
+	static int prev = 0;
+
+	if (prev != col)
+		uiTableHeaderSetSortIndicator(t, prev, uiSortIndicatorNone);
+
+	if (uiTableHeaderSortIndicator(t, col) == uiSortIndicatorAscending)
+		uiTableHeaderSetSortIndicator(t, col, uiSortIndicatorDescending);
+	else
+		uiTableHeaderSetSortIndicator(t, col, uiSortIndicatorAscending);
+
+	prev = col;
+}
+
 uiBox *makePage16(void)
 {
 	uiBox *page16;
@@ -151,6 +166,8 @@ uiBox *makePage16(void)
 
 	uiTableAppendProgressBarColumn(t, "Progress Bar",
 		8);
+
+	uiTableHeaderOnClicked(t, headerOnClicked, NULL);
 
 	return page16;
 }

--- a/ui.h
+++ b/ui.h
@@ -1261,6 +1261,12 @@ _UI_EXTERN uiTableValue *uiNewTableValueColor(double r, double g, double b, doub
 // TODO define whether all this, for both uiTableValue and uiAttribute, is undefined behavior or a caught error
 _UI_EXTERN void uiTableValueColor(const uiTableValue *v, double *r, double *g, double *b, double *a);
 
+_UI_ENUM(uiSortIndicator) {
+	uiSortIndicatorNone,
+	uiSortIndicatorAscending,
+	uiSortIndicatorDescending
+};
+
 // uiTableModel is an object that provides the data for a uiTable.
 // This data is returned via methods you provide in the
 // uiTableModelHandler struct.

--- a/ui.h
+++ b/ui.h
@@ -1470,6 +1470,22 @@ _UI_EXTERN void uiTableAppendButtonColumn(uiTable *t,
 // uiNewTable() creates a new uiTable with the specified parameters.
 _UI_EXTERN uiTable *uiNewTable(uiTableParams *params);
 
+// uiTableHeaderSetSortIndicator() sets the sort indicator of the table
+// header to display an appropriate arrow on the column header
+_UI_EXTERN void uiTableHeaderSetSortIndicator(uiTable *t,
+	int column,
+	uiSortIndicator indicator);
+
+// uiTableHeaderSortIndicator returns the sort indicator of the specified
+// column
+_UI_EXTERN uiSortIndicator uiTableHeaderSortIndicator(uiTable *t, int column);
+
+// uiTableHeaderOnClicked() sets a callback function to be called
+// when a table column header is clicked
+_UI_EXTERN void uiTableHeaderOnClicked(uiTable *t,
+	void (*f)(uiTable *table, int column, void *data),
+	void *data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/unix/table.c
+++ b/unix/table.c
@@ -18,6 +18,8 @@ struct uiTable {
 	// TODO document this properly
 	GHashTable *indeterminatePositions;
 	guint indeterminateTimer;
+	void (*headerOnClicked)(uiTable *, int, void *);
+	void *headerOnClickedData;
 };
 
 // use the same size as GtkFileChooserWidget's treeview
@@ -327,6 +329,59 @@ static void buttonColumnClicked(GtkCellRenderer *r, gchar *pathstr, gpointer dat
 	onEdited(p->m, p->modelColumn, pathstr, NULL, NULL);
 }
 
+uiSortIndicator uiTableHeaderSortIndicator(uiTable *t, int lcol)
+{
+	GtkTreeViewColumn *c = gtk_tree_view_get_column(t->tv, lcol);
+
+	if (c == NULL || gtk_tree_view_column_get_sort_indicator(c) == FALSE)
+		return uiSortIndicatorNone;
+
+	if (gtk_tree_view_column_get_sort_order(c) == GTK_SORT_ASCENDING)
+		return uiSortIndicatorAscending;
+	else
+		return uiSortIndicatorDescending;
+}
+
+void uiTableHeaderSetSortIndicator(uiTable *t, int lcol, uiSortIndicator indicator)
+{
+	GtkTreeViewColumn *c = gtk_tree_view_get_column(t->tv, lcol);
+
+	if (c == NULL)
+		return;
+
+	if (indicator == uiSortIndicatorNone) {
+		gtk_tree_view_column_set_sort_indicator(c, FALSE);
+		return;
+	}
+
+	gtk_tree_view_column_set_sort_indicator(c, TRUE);
+	if (indicator == uiSortIndicatorAscending)
+		gtk_tree_view_column_set_sort_order(c, GTK_SORT_ASCENDING);
+	else
+		gtk_tree_view_column_set_sort_order(c, GTK_SORT_DESCENDING);
+}
+
+void uiTableHeaderOnClicked(uiTable *t, void (*f)(uiTable *, int, void *), void *data)
+{
+	t->headerOnClicked = f;
+	t->headerOnClickedData = data;
+}
+
+static void defaultHeaderOnClicked(uiTable *table, int column, void *data)
+{
+	// do nothing
+}
+
+static void headerOnClicked(GtkTreeViewColumn *c, gpointer data)
+{
+	guint i;
+	uiTable *t = uiTable(data);
+
+	for (i = 0; i < gtk_tree_view_get_n_columns(t->tv); ++i)
+		if (gtk_tree_view_get_column(t->tv, i) == c)
+			t->headerOnClicked(t, i, t->headerOnClickedData);
+}
+
 static GtkTreeViewColumn *addColumn(uiTable *t, const char *name)
 {
 	GtkTreeViewColumn *c;
@@ -334,6 +389,8 @@ static GtkTreeViewColumn *addColumn(uiTable *t, const char *name)
 	c = gtk_tree_view_column_new();
 	gtk_tree_view_column_set_resizable(c, TRUE);
 	gtk_tree_view_column_set_title(c, name);
+	gtk_tree_view_column_set_clickable(c, 1);
+	g_signal_connect(c, "clicked", G_CALLBACK(headerOnClicked), t);
 	gtk_tree_view_append_column(t->tv, c);
 	return c;
 }
@@ -519,6 +576,8 @@ uiTable *uiNewTable(uiTableParams *p)
 
 	t->indeterminatePositions = g_hash_table_new_full(rowcolHash, rowcolEqual,
 		uiprivFree, uiprivFree);
+
+	uiTableHeaderOnClicked(t, defaultHeaderOnClicked, NULL);
 
 	return t;
 }

--- a/windows/table.hpp
+++ b/windows/table.hpp
@@ -40,6 +40,8 @@ struct uiTable {
 	HWND edit;
 	int editedItem;
 	int editedSubitem;
+	void (*headerOnClicked)(uiTable *, int, void *);
+	void *headerOnClickedData;
 };
 extern int uiprivTableProgress(uiTable *t, int item, int subitem, int modelColumn, LONG *pos);
 


### PR DESCRIPTION
Old PR  [libui#513](https://github.com/andlabs/libui/pull/513) 

Proposal for introducing an enum sort type `uiSort`:
```c
uiSortIndicatorNone
uiSortIndicatorAscending
uiSortIndicatorDescending
```
Two functions for setting table header sort indicators (only visual, no sorting is performed):
```c
uiSort uiTableHeaderSortIndicator(uiTable *t, int column);
void uiTableHeaderSetSortIndicator(uiTable *t, int column, uiSortIndiactor indicator);
```
And a setter for a header on clicked callback function:
```c
void uiTableHeaderOnClicked(uiTable *t, void (*f)(uiTable *table, int column, void *data), void *data);
```

Implementations are provided for darwin, unix, and windows.

Notes: The column is the index of the column when it was added to the table. It might be nice to be able to set a numeric identifier, similar to how table columns are handled on darwin. Or possibly even introducing a `uiTableColumn` type and cleaning up the `uiTableAppendColumn` API. This would however break the existing API, so I left it out for the time being. 