### PR TITLE
[Old PR lubui#381] Add uiSliderSetRange function to API 

### DIFF
--- a/darwin/slider.m
+++ b/darwin/slider.m
@@ -109,6 +109,20 @@ static void defaultOnChanged(uiSlider *s, void *data)
 	// do nothing
 }
 
+void uiSliderSetRange(uiSlider *s, int min, int max)
+{
+	int temp;
+
+	if (min >= max) {
+		temp = min;
+		min = max;
+		max = temp;
+	}
+
+	[s->slider setMinValue:min];
+	[s->slider setMaxValue:max];
+}
+
 uiSlider *uiNewSlider(int min, int max)
 {
 	uiSlider *s;

--- a/test/page4.c
+++ b/test/page4.c
@@ -4,6 +4,9 @@
 static uiSpinbox *spinbox;
 static uiSlider *slider;
 static uiProgressBar *pbar;
+static uiSpinbox *spinboxFrom;
+static uiSpinbox *spinboxTo;
+
 
 #define CHANGED(what) \
 	static void on ## what ## Changed(ui ## what *this, void *data) \
@@ -90,6 +93,25 @@ static void selectNone(uiButton *b, void *data)
 	uiRadioButtonsSetSelected(rb, -1);
 }
 
+static void setSliderRange(uiSpinbox *spinbox, void *data)
+{
+	uiSlider *s = data;
+
+	uiSliderSetRange(s, uiSpinboxValue(spinboxFrom), uiSpinboxValue(spinboxTo));
+}
+
+static void onRangeSliderChanged(uiSlider *s, void *data)
+{
+	char str[128];
+	uiLabel *lbl = data;
+
+	// snprintf() is not supported by visual studio 2013:
+	// http://blogs.msdn.com/b/vcblog/archive/2013/07/19/c99-library-support-in-visual-studio-2013.aspx
+	// we can't use _snprintf() in the test suite because that's msvc-only, so sprintf() it is.
+	sprintf(str, "%d", uiSliderValue(s));
+	uiLabelSetText(lbl, str);
+}
+
 uiBox *makePage4(void)
 {
 	uiBox *page4;
@@ -97,6 +119,7 @@ uiBox *makePage4(void)
 	uiSpinbox *xsb;
 	uiButton *b;
 	uiSlider *xsl;
+	uiLabel *lbl;
 
 	page4 = newVerticalBox();
 
@@ -133,6 +156,24 @@ uiBox *makePage4(void)
 	b = uiNewButton("Bad High");
 	uiButtonOnClicked(b, setSliderTooHigh, xsl);
 	uiBoxAppend(hbox, uiControl(b), 0);
+	uiBoxAppend(page4, uiControl(hbox), 0);
+
+	uiBoxAppend(page4, uiControl(uiNewHorizontalSeparator()), 0);
+
+	lbl = uiNewLabel("100");
+	uiBoxAppend(page4, uiControl(lbl), 0);
+	hbox = newHorizontalBox();
+	spinboxFrom = uiNewSpinbox(0, 1000);
+	uiSpinboxSetValue(spinboxFrom, 100);
+	uiBoxAppend(hbox, uiControl(spinboxFrom), 1);
+	xsl = uiNewSlider(100, 200);
+	uiSpinboxOnChanged(spinboxFrom, setSliderRange, xsl);
+	uiBoxAppend(hbox, uiControl(xsl), 1);
+	uiSliderOnChanged(xsl, onRangeSliderChanged, lbl);
+	spinboxTo = uiNewSpinbox(0, 1000);
+	uiSpinboxSetValue(spinboxTo, 200);
+	uiSpinboxOnChanged(spinboxTo, setSliderRange, xsl);
+	uiBoxAppend(hbox, uiControl(spinboxTo), 1);
 	uiBoxAppend(page4, uiControl(hbox), 0);
 
 	uiBoxAppend(page4, uiControl(uiNewHorizontalSeparator()), 0);

--- a/ui.h
+++ b/ui.h
@@ -213,6 +213,7 @@ typedef struct uiSlider uiSlider;
 _UI_EXTERN int uiSliderValue(uiSlider *s);
 _UI_EXTERN void uiSliderSetValue(uiSlider *s, int value);
 _UI_EXTERN void uiSliderOnChanged(uiSlider *s, void (*f)(uiSlider *s, void *data), void *data);
+_UI_EXTERN void uiSliderSetRange(uiSlider *s, int min, int max);
 _UI_EXTERN uiSlider *uiNewSlider(int min, int max);
 
 typedef struct uiProgressBar uiProgressBar;

--- a/unix/slider.c
+++ b/unix/slider.c
@@ -44,6 +44,22 @@ void uiSliderOnChanged(uiSlider *s, void (*f)(uiSlider *, void *), void *data)
 	s->onChangedData = data;
 }
 
+void uiSliderSetRange(uiSlider *s, int min, int max)
+{
+	int temp;
+
+	if (min >= max) {
+		temp = min;
+		min = max;
+		max = temp;
+	}
+
+	// we need to inhibit sending of ::value-changed because this WILL send a ::value-changed otherwise
+	g_signal_handler_block(s->range, s->onChangedSignal);
+	gtk_range_set_range(s->range, min, max);
+	g_signal_handler_unblock(s->range, s->onChangedSignal);
+}
+
 uiSlider *uiNewSlider(int min, int max)
 {
 	uiSlider *s;

--- a/windows/slider.cpp
+++ b/windows/slider.cpp
@@ -68,6 +68,20 @@ void uiSliderOnChanged(uiSlider *s, void (*f)(uiSlider *, void *), void *data)
 	s->onChangedData = data;
 }
 
+void uiSliderSetRange(uiSlider *s, int min, int max)
+{
+	int temp;
+
+	if (min >= max) {
+		temp = min;
+		min = max;
+		max = temp;
+	}
+
+	SendMessageW(s->hwnd, TBM_SETRANGEMIN, (WPARAM) TRUE, (LPARAM) min);
+	SendMessageW(s->hwnd, TBM_SETRANGEMAX, (WPARAM) TRUE, (LPARAM) max);
+}
+
 uiSlider *uiNewSlider(int min, int max)
 {
 	uiSlider *s;


### PR DESCRIPTION
Old PR [libui#381](https://github.com/andlabs/libui/pull/381)

Add a function to the slider API to modify the slider range after slider creation.

```c
void uiSliderSetRange(uiSlider *s, int min, int max);
```

Also mentioned as possible API addition in [libui#309](https://github.com/andlabs/libui/issues/309)

Tested on linux, mac, and wine/mingw-w64.