### PR TITLE
 [Old PR libui#424] Make slider tool tip default on all platforms. Add API functions to enable/disable slider tool tips.

### DIFF
--- a/darwin/slider.m
+++ b/darwin/slider.m
@@ -26,7 +26,10 @@ struct uiSlider {
 	NSSlider *slider;
 	void (*onChanged)(uiSlider *, void *);
 	void *onChangedData;
+	bool hasToolTip;
 };
+
+static void _uiSliderUpdateToolTip(uiSlider *s);
 
 @interface sliderDelegateClass : NSObject {
 	uiprivMap *sliders;
@@ -58,6 +61,9 @@ struct uiSlider {
 
 	s = (uiSlider *) uiprivMapGet(self->sliders, sender);
 	(*(s->onChanged))(s, s->onChangedData);
+
+	if (s->hasToolTip)
+		_uiSliderUpdateToolTip(s);
 }
 
 - (void)registerSlider:(uiSlider *)s
@@ -86,6 +92,26 @@ static void uiSliderDestroy(uiControl *c)
 	[sliderDelegate unregisterSlider:s];
 	[s->slider release];
 	uiFreeControl(uiControl(s));
+}
+
+static void _uiSliderUpdateToolTip(uiSlider *s)
+{
+	[s->slider setToolTip:[NSString stringWithFormat:@"%ld", [s->slider integerValue]]];
+}
+
+int uiSliderHasToolTip(uiSlider *s)
+{
+	return s->hasToolTip;
+}
+
+void uiSliderSetHasToolTip(uiSlider *s, int hasToolTip)
+{
+	s->hasToolTip = hasToolTip;
+
+	if (hasToolTip)
+		_uiSliderUpdateToolTip(s);
+	else
+		[s->slider setToolTip:nil];
 }
 
 int uiSliderValue(uiSlider *s)
@@ -142,6 +168,8 @@ uiSlider *uiNewSlider(int min, int max)
 	}
 	[sliderDelegate registerSlider:s];
 	uiSliderOnChanged(s, defaultOnChanged, NULL);
+
+	uiSliderSetHasToolTip(s, 1);
 
 	return s;
 }

--- a/test/page4.c
+++ b/test/page4.c
@@ -4,6 +4,7 @@
 static uiSpinbox *spinbox;
 static uiSlider *slider;
 static uiProgressBar *pbar;
+static uiCheckbox *checkbox;
 
 #define CHANGED(what) \
 	static void on ## what ## Changed(ui ## what *this, void *data) \
@@ -90,6 +91,18 @@ static void selectNone(uiButton *b, void *data)
 	uiRadioButtonsSetSelected(rb, -1);
 }
 
+static void sliderEnableToolTip(uiButton *b, void *data)
+{
+	uiSliderSetHasToolTip(uiSlider(data), 1);
+	uiCheckboxSetChecked(checkbox, uiSliderHasToolTip(uiSlider(data)));
+}
+
+static void sliderDisableToolTip(uiButton *b, void *data)
+{
+	uiSliderSetHasToolTip(uiSlider(data), 0);
+	uiCheckboxSetChecked(checkbox, uiSliderHasToolTip(uiSlider(data)));
+}
+
 uiBox *makePage4(void)
 {
 	uiBox *page4;
@@ -107,6 +120,21 @@ uiBox *makePage4(void)
 	slider = uiNewSlider(0, 100);
 	uiSliderOnChanged(slider, onSliderChanged, NULL);
 	uiBoxAppend(page4, uiControl(slider), 0);
+
+	hbox = newHorizontalBox();
+	slider = uiNewSlider(0, 100);
+	uiBoxAppend(hbox, uiControl(slider), 1);
+	b = uiNewButton("Enable ToolTip");
+	uiButtonOnClicked(b, sliderEnableToolTip, slider);
+	uiBoxAppend(hbox, uiControl(b), 0);
+	b = uiNewButton("Disable ToolTip");
+	uiButtonOnClicked(b, sliderDisableToolTip, slider);
+	uiBoxAppend(hbox, uiControl(b), 0);
+	checkbox = uiNewCheckbox("Has ToolTip");
+	uiControlDisable(uiControl(checkbox));
+	uiCheckboxSetChecked(checkbox, uiSliderHasToolTip(slider));
+	uiBoxAppend(hbox, uiControl(checkbox), 0);
+	uiBoxAppend(page4, uiControl(hbox), 0);
 
 	pbar = uiNewProgressBar();
 	uiBoxAppend(page4, uiControl(pbar), 0);

--- a/ui.h
+++ b/ui.h
@@ -212,6 +212,8 @@ typedef struct uiSlider uiSlider;
 #define uiSlider(this) ((uiSlider *) (this))
 _UI_EXTERN int uiSliderValue(uiSlider *s);
 _UI_EXTERN void uiSliderSetValue(uiSlider *s, int value);
+_UI_EXTERN int uiSliderHasToolTip(uiSlider *s);
+_UI_EXTERN void uiSliderSetHasToolTip(uiSlider *s, int hasToolTip);
 _UI_EXTERN void uiSliderOnChanged(uiSlider *s, void (*f)(uiSlider *s, void *data), void *data);
 _UI_EXTERN uiSlider *uiNewSlider(int min, int max);
 

--- a/unix/slider.c
+++ b/unix/slider.c
@@ -1,6 +1,12 @@
 // 11 june 2015
 #include "uipriv_unix.h"
 
+/* Number of digits to represent an n-bit number in decimal: log10(2^n)
+ * Simplify, truncate & add 1 for full digits, add 1 for negative numbers:
+ *   -> n log10(2) + 2   <=   n * 0.302 + 2
+ */
+#define MAX_STRLEN_FOR_NBITS_IN_DECIMAL(n) ((int)((n) * 302 / 1000) + 2)
+
 struct uiSlider {
 	uiUnixControl c;
 	GtkWidget *widget;
@@ -9,15 +15,25 @@ struct uiSlider {
 	void (*onChanged)(uiSlider *, void *);
 	void *onChangedData;
 	gulong onChangedSignal;
+	gchar tooltip[MAX_STRLEN_FOR_NBITS_IN_DECIMAL(sizeof(int) * CHAR_BIT) + 1];
 };
 
 uiUnixControlAllDefaults(uiSlider)
+
+static void _uiSliderUpdateToolTip(uiSlider *s)
+{
+	g_snprintf(s->tooltip, sizeof(s->tooltip)/sizeof(s->tooltip[0]), "%d", uiSliderValue(s));
+	gtk_widget_set_tooltip_text(s->widget, s->tooltip);
+}
 
 static void onChanged(GtkRange *range, gpointer data)
 {
 	uiSlider *s = uiSlider(data);
 
 	(*(s->onChanged))(s, s->onChangedData);
+
+	if (uiSliderHasToolTip(s))
+		_uiSliderUpdateToolTip(s);
 }
 
 static void defaultOnChanged(uiSlider *s, void *data)
@@ -36,6 +52,19 @@ void uiSliderSetValue(uiSlider *s, int value)
 	g_signal_handler_block(s->range, s->onChangedSignal);
 	gtk_range_set_value(s->range, value);
 	g_signal_handler_unblock(s->range, s->onChangedSignal);
+}
+
+int uiSliderHasToolTip(uiSlider *s)
+{
+	return gtk_widget_get_has_tooltip(s->widget);
+}
+
+void uiSliderSetHasToolTip(uiSlider *s, int hasToolTip)
+{
+	gtk_widget_set_has_tooltip(s->widget, hasToolTip);
+
+	if (hasToolTip)
+		_uiSliderUpdateToolTip(s);
 }
 
 void uiSliderOnChanged(uiSlider *s, void (*f)(uiSlider *, void *), void *data)
@@ -60,6 +89,10 @@ uiSlider *uiNewSlider(int min, int max)
 	s->widget = gtk_scale_new_with_range(GTK_ORIENTATION_HORIZONTAL, min, max, 1);
 	s->range = GTK_RANGE(s->widget);
 	s->scale = GTK_SCALE(s->widget);
+
+	// do not draw value, show tooltip instead
+	gtk_scale_set_draw_value(s->scale, 0);
+	uiSliderSetHasToolTip(s, 1);
 
 	// ensure integers, just to be safe
 	gtk_scale_set_digits(s->scale, 0);

--- a/windows/slider.cpp
+++ b/windows/slider.cpp
@@ -6,6 +6,7 @@ struct uiSlider {
 	HWND hwnd;
 	void (*onChanged)(uiSlider *, void *);
 	void *onChangedData;
+	HWND hwndToolTip;
 };
 
 static BOOL onWM_HSCROLL(uiControl *c, HWND hwnd, WORD code, LRESULT *lResult)
@@ -20,6 +21,9 @@ static BOOL onWM_HSCROLL(uiControl *c, HWND hwnd, WORD code, LRESULT *lResult)
 static void uiSliderDestroy(uiControl *c)
 {
 	uiSlider *s = uiSlider(c);
+
+	// ensure TRACKBAR_CLASSW takes care of destroying the tooltip
+	uiSliderSetHasToolTip(s, 1);
 
 	uiWindowsUnregisterWM_HSCROLLHandler(s->hwnd);
 	uiWindowsEnsureDestroyWindow(s->hwnd);
@@ -44,6 +48,19 @@ static void uiSliderMinimumSize(uiWindowsControl *c, int *width, int *height)
 	uiWindowsSizingDlgUnitsToPixels(&sizing, &x, &y);
 	*width = x;
 	*height = y;
+}
+
+int uiSliderHasToolTip(uiSlider *s)
+{
+	return ((HWND) SendMessage(s->hwnd, TBM_GETTOOLTIPS, 0, 0) == s->hwndToolTip);
+}
+
+void uiSliderSetHasToolTip(uiSlider *s, int hasToolTip)
+{
+	if (hasToolTip)
+		SendMessage(s->hwnd, TBM_SETTOOLTIPS, (WPARAM) s->hwndToolTip, 0);
+	else
+		SendMessage(s->hwnd, TBM_SETTOOLTIPS, 0, 0);
 }
 
 static void defaultOnChanged(uiSlider *s, void *data)
@@ -93,6 +110,8 @@ uiSlider *uiNewSlider(int min, int max)
 	SendMessageW(s->hwnd, TBM_SETRANGEMIN, (WPARAM) TRUE, (LPARAM) min);
 	SendMessageW(s->hwnd, TBM_SETRANGEMAX, (WPARAM) TRUE, (LPARAM) max);
 	SendMessageW(s->hwnd, TBM_SETPOS, (WPARAM) TRUE, (LPARAM) min);
+
+	s->hwndToolTip = (HWND) SendMessage(s->hwnd, TBM_GETTOOLTIPS, 0, 0);
 
 	return s;
 }


### PR DESCRIPTION
Old PR [libui#424](https://github.com/andlabs/libui/pull/424)

As can be seen in the README screenshots the slider is not consistent across platforms.

This PR does:
- Disable value drawn over the slider on unix platforms
- Draw tool tip on unix
- Draw tool tip on windos
- Keep existing tooltip on windows
- Add API function to enable and disable tool tips.

```c
int uiSliderHasToolTip(uiSlider *s);
void uiSliderSetHasToolTip(uiSlider *s, int hasToolTip);
```

Tested on Linux, macOS and wine/mingw-w64.