### PR TITLE
[Old PR libui#190] add uiOpenFolder API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- uiOpenFolder API
 - uiTableHeaderSortIndicator() API
 - uiTableHeaderSetSortIndicator() API
 - uiTableHeaderOnClicked() API

--- a/darwin/stddialogs.m
+++ b/darwin/stddialogs.m
@@ -46,6 +46,20 @@ char *uiOpenFile(uiWindow *parent)
 	return runSavePanel(windowWindow(parent), o);
 }
 
+char *uiOpenFolder(uiWindow *parent)
+{
+	NSOpenPanel *o;
+
+	o = [NSOpenPanel openPanel];
+	[o setCanChooseFiles:NO];
+	[o setCanChooseDirectories:YES];
+	[o setResolvesAliases:NO];
+	[o setAllowsMultipleSelection:NO];
+	setupSavePanel(o);
+	// panel is autoreleased
+	return runSavePanel(windowWindow(parent), o);
+}
+
 char *uiSaveFile(uiWindow *parent)
 {
 	NSSavePanel *s;

--- a/examples/controlgallery/main.c
+++ b/examples/controlgallery/main.c
@@ -175,6 +175,20 @@ static void onOpenFileClicked(uiButton *b, void *data)
 	uiFreeText(filename);
 }
 
+static void onOpenFolderClicked(uiButton *b, void *data)
+{
+	uiEntry *entry = uiEntry(data);
+	char *filename;
+
+	filename = uiOpenFolder(mainwin);
+	if (filename == NULL) {
+		uiEntrySetText(entry, "(cancelled)");
+		return;
+	}
+	uiEntrySetText(entry, filename);
+	uiFreeText(filename);
+}
+
 static void onSaveFileClicked(uiButton *b, void *data)
 {
 	uiEntry *entry = uiEntry(data);
@@ -259,10 +273,10 @@ static uiControl *makeDataChoosersPage(void)
 		1, 0, 1, 1,
 		1, uiAlignFill, 0, uiAlignFill);
 
-	button = uiNewButton("Save File");
+	button = uiNewButton("Open Folder");
 	entry = uiNewEntry();
 	uiEntrySetReadOnly(entry, 1);
-	uiButtonOnClicked(button, onSaveFileClicked, entry);
+	uiButtonOnClicked(button, onOpenFolderClicked, entry);
 	uiGridAppend(grid, uiControl(button),
 		0, 1, 1, 1,
 		0, uiAlignFill, 0, uiAlignFill);
@@ -270,10 +284,21 @@ static uiControl *makeDataChoosersPage(void)
 		1, 1, 1, 1,
 		1, uiAlignFill, 0, uiAlignFill);
 
+	button = uiNewButton("Save File");
+	entry = uiNewEntry();
+	uiEntrySetReadOnly(entry, 1);
+	uiButtonOnClicked(button, onSaveFileClicked, entry);
+	uiGridAppend(grid, uiControl(button),
+		0, 2, 1, 1,
+		0, uiAlignFill, 0, uiAlignFill);
+	uiGridAppend(grid, uiControl(entry),
+		1, 2, 1, 1,
+		1, uiAlignFill, 0, uiAlignFill);
+
 	msggrid = uiNewGrid();
 	uiGridSetPadded(msggrid, 1);
 	uiGridAppend(grid, uiControl(msggrid),
-		0, 2, 2, 1,
+		0, 3, 2, 1,
 		0, uiAlignCenter, 0, uiAlignStart);
 
 	button = uiNewButton("Message Box");
@@ -341,6 +366,19 @@ static void openClicked(uiMenuItem *item, uiWindow *w, void *data)
 	uiFreeText(filename);
 }
 
+static void openFolderClicked(uiMenuItem *item, uiWindow *w, void *data)
+{
+	char *filename;
+
+	filename = uiOpenFolder(mainwin);
+	if (filename == NULL) {
+		uiMsgBoxError(mainwin, "No folder selected", "Don't be alarmed!");
+		return;
+	}
+	uiMsgBox(mainwin, "Folder selected", filename);
+	uiFreeText(filename);
+}
+
 static void saveClicked(uiMenuItem *item, uiWindow *w, void *data)
 {
 	char *filename;
@@ -403,6 +441,8 @@ int main(void)
 	menu = uiNewMenu("File");
 	item = uiMenuAppendItem(menu, "Open");
 	uiMenuItemOnClicked(item, openClicked, NULL);
+	item = uiMenuAppendItem(menu, "Open Folder");
+	uiMenuItemOnClicked(item, openFolderClicked, NULL);
 	item = uiMenuAppendItem(menu, "Save");
 	uiMenuItemOnClicked(item, saveClicked, NULL);
 	item = uiMenuAppendQuitItem(menu);

--- a/test/page5.c
+++ b/test/page5.c
@@ -16,6 +16,19 @@ static void openFile(uiButton *b, void *data)
 	}
 }
 
+static void openFolder(uiButton *b, void *data)
+{
+	char *fn;
+
+	fn = uiOpenFolder(parent);
+	if (fn == NULL)
+		uiLabelSetText(uiLabel(data), "(cancelled)");
+	else {
+		uiLabelSetText(uiLabel(data), fn);
+		uiFreeText(fn);
+	}
+}
+
 static void saveFile(uiButton *b, void *data)
 {
 	char *fn;
@@ -74,6 +87,7 @@ uiBox *makePage5(uiWindow *pw)
 	uiBoxAppend(page5, uiControl(hbox), 0);
 
 	D("Open File", openFile);
+	D("Open Folder", openFolder);
 	D("Save File", saveFile);
 
 	title = uiNewEntry();

--- a/ui.h
+++ b/ui.h
@@ -300,6 +300,7 @@ _UI_EXTERN void uiMenuAppendSeparator(uiMenu *m);
 _UI_EXTERN uiMenu *uiNewMenu(const char *name);
 
 _UI_EXTERN char *uiOpenFile(uiWindow *parent);
+_UI_EXTERN char *uiOpenFolder(uiWindow *parent);
 _UI_EXTERN char *uiSaveFile(uiWindow *parent);
 _UI_EXTERN void uiMsgBox(uiWindow *parent, const char *title, const char *description);
 _UI_EXTERN void uiMsgBoxError(uiWindow *parent, const char *title, const char *description);

--- a/unix/stddialogs.c
+++ b/unix/stddialogs.c
@@ -38,6 +38,11 @@ char *uiOpenFile(uiWindow *parent)
 	return filedialog(windowWindow(parent), GTK_FILE_CHOOSER_ACTION_OPEN, "_Open");
 }
 
+char *uiOpenFolder(uiWindow *parent)
+{
+	return filedialog(windowWindow(parent), GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER, "_Open");
+}
+
 char *uiSaveFile(uiWindow *parent)
 {
 	return filedialog(windowWindow(parent), GTK_FILE_CHOOSER_ACTION_SAVE, "_Save");

--- a/windows/stddialogs.cpp
+++ b/windows/stddialogs.cpp
@@ -88,6 +88,18 @@ char *uiOpenFile(uiWindow *parent)
 	return res;
 }
 
+char *uiOpenFolder(uiWindow *parent)
+{
+	char *res;
+
+	disableAllWindowsExcept(parent);
+	res = commonItemDialog(windowHWND(parent),
+		CLSID_FileOpenDialog, IID_IFileOpenDialog,
+		FOS_NOCHANGEDIR | FOS_ALLNONSTORAGEITEMS | FOS_NOVALIDATE | FOS_PATHMUSTEXIST | FOS_PICKFOLDERS | FOS_SHAREAWARE | FOS_NOTESTFILECREATE | FOS_NODEREFERENCELINKS | FOS_FORCESHOWHIDDEN | FOS_DEFAULTNOMINIMODE);
+	enableAllWindowsExcept(parent);
+	return res;
+}
+
 char *uiSaveFile(uiWindow *parent)
 {
 	char *res;


### PR DESCRIPTION
Main part of [libui#190](https://github.com/andlabs/libui/pull/190)

Remaining parts are:
- add filename to `uiSaveFile` - implemented for linux and windows, macos missed
- add `uiWindowSetTopmost` - implemented for linux, macos and windows missed

Can do remaining parts in separate PR, if needed.