### PR TITLE
[Old PR libui#514] Add new API functions to get/set table column widths. #514 

### DIFF
--- a/darwin/table.m
+++ b/darwin/table.m
@@ -286,3 +286,15 @@ void uiTableHeaderSetSortIndicator(uiTable *t, int lcol, uiSortIndicator indicat
 		img = nil;
 	[t->tv setIndicatorImage:img inTableColumn:tc];
 }
+
+int uiTableColumnWidth(uiTable *t, int column)
+{
+	NSTableColumn *tc = [t->tv tableColumnWithIdentifier:[@(column) stringValue]];
+	return [tc width];
+}
+
+void uiTableColumnSetWidth(uiTable *t, int column, int width)
+{
+	NSTableColumn *tc = [t->tv tableColumnWithIdentifier:[@(column) stringValue]];
+	[tc setWidth: width];
+}

--- a/darwin/table.m
+++ b/darwin/table.m
@@ -296,5 +296,10 @@ int uiTableColumnWidth(uiTable *t, int column)
 void uiTableColumnSetWidth(uiTable *t, int column, int width)
 {
 	NSTableColumn *tc = [t->tv tableColumnWithIdentifier:[@(column) stringValue]];
-	[tc setWidth: width];
+
+	if (width == -1)
+		//TODO: resize not only to header but also to max content width
+		[tc sizeToFit];
+	else
+		[tc setWidth: width];
 }

--- a/test/page16.c
+++ b/test/page16.c
@@ -105,6 +105,20 @@ void headerVisibleToggled(uiCheckbox *c, void *data)
 	uiCheckboxSetChecked(c, uiTableHeaderVisible(t));
 }
 
+uiSpinbox *columnID;
+uiSpinbox *columnWidth;
+static void changedColumnID(uiSpinbox *s, void *data)
+{
+	uiTable *t = data;
+	uiSpinboxSetValue(columnWidth, uiTableColumnWidth(t, uiSpinboxValue(columnID)));
+}
+
+static void changedColumnWidth(uiSpinbox *s, void *data)
+{
+	uiTable *t = data;
+	uiTableColumnSetWidth(t, uiSpinboxValue(columnID), uiSpinboxValue(columnWidth));
+}
+
 static uiTableModel *m;
 
 static void headerOnClicked(uiTable *t, int col, void *data)
@@ -144,6 +158,7 @@ uiBox *makePage16(void)
 
 	page16 = newVerticalBox();
 	controls = newHorizontalBox();
+	uiBoxSetPadded(controls, 1);
 	uiBoxAppend(page16, uiControl(controls), 0);
 
 	mh.NumColumns = modelNumColumns;
@@ -184,6 +199,18 @@ uiBox *makePage16(void)
 	uiCheckboxSetChecked(headerVisible, uiTableHeaderVisible(t));
 	uiCheckboxOnToggled(headerVisible, headerVisibleToggled, t);
 	uiBoxAppend(controls, uiControl(headerVisible), 0);
+
+	uiBoxAppend(controls, uiControl(uiNewVerticalSeparator()), 0);
+
+	uiBoxAppend(controls, uiControl(uiNewLabel("Column")), 0);
+	columnID = uiNewSpinbox(0, 5);
+	uiBoxAppend(controls, uiControl(columnID), 0);
+	uiBoxAppend(controls, uiControl(uiNewLabel("Width")), 0);
+	columnWidth = uiNewSpinbox(0, INT_MAX);
+	uiBoxAppend(controls, uiControl(columnWidth), 0);
+
+	uiSpinboxOnChanged(columnID, changedColumnID, t);
+	uiSpinboxOnChanged(columnWidth, changedColumnWidth, t);
 
 	return page16;
 }

--- a/test/page16.c
+++ b/test/page16.c
@@ -206,7 +206,7 @@ uiBox *makePage16(void)
 	columnID = uiNewSpinbox(0, 5);
 	uiBoxAppend(controls, uiControl(columnID), 0);
 	uiBoxAppend(controls, uiControl(uiNewLabel("Width")), 0);
-	columnWidth = uiNewSpinbox(0, INT_MAX);
+	columnWidth = uiNewSpinbox(-1, INT_MAX);
 	uiBoxAppend(controls, uiControl(columnWidth), 0);
 
 	uiSpinboxOnChanged(columnID, changedColumnID, t);

--- a/ui.h
+++ b/ui.h
@@ -1512,6 +1512,7 @@ _UI_EXTERN int uiTableColumnWidth(uiTable *t, int column);
 // uiTableColumnSetWidth() set table column width
 // Setting width to -1 will restore automatic column sizing matching either
 // the width of the content or header title (which ever one is bigger)
+// Note: darwin currently only resizes to header title width on -1
 _UI_EXTERN void uiTableColumnSetWidth(uiTable *t, int column, int width);
 
 #ifdef __cplusplus

--- a/ui.h
+++ b/ui.h
@@ -1510,6 +1510,8 @@ _UI_EXTERN void uiTableHeaderOnClicked(uiTable *t,
 _UI_EXTERN int uiTableColumnWidth(uiTable *t, int column);
 
 // uiTableColumnSetWidth() set table column width
+// Setting width to -1 will restore automatic column sizing matching either
+// the width of the content or header title (which ever one is bigger)
 _UI_EXTERN void uiTableColumnSetWidth(uiTable *t, int column, int width);
 
 #ifdef __cplusplus

--- a/ui.h
+++ b/ui.h
@@ -1506,6 +1506,12 @@ _UI_EXTERN void uiTableHeaderOnClicked(uiTable *t,
 	void (*f)(uiTable *table, int column, void *data),
 	void *data);
 
+// uiTableColumnWidth() return current table column width
+_UI_EXTERN int uiTableColumnWidth(uiTable *t, int column);
+
+// uiTableColumnSetWidth() set table column width
+_UI_EXTERN void uiTableColumnSetWidth(uiTable *t, int column, int width);
+
 #ifdef __cplusplus
 }
 #endif

--- a/unix/table.c
+++ b/unix/table.c
@@ -591,3 +591,15 @@ uiTable *uiNewTable(uiTableParams *p)
 
 	return t;
 }
+
+int uiTableColumnWidth(uiTable *t, int column)
+{
+	GtkTreeViewColumn *c = gtk_tree_view_get_column(t->tv, column);
+	return gtk_tree_view_column_get_width(c);
+}
+
+void uiTableColumnSetWidth(uiTable *t, int column, int width)
+{
+	GtkTreeViewColumn *c = gtk_tree_view_get_column(t->tv, column);
+	gtk_tree_view_column_set_fixed_width(c, width);
+}

--- a/windows/table.cpp
+++ b/windows/table.cpp
@@ -588,10 +588,10 @@ uiTable *uiNewTable(uiTableParams *p)
 
 int uiTableColumnWidth(uiTable *t, int column)
 {
-	return ListView_GetColumnWidth(t->hwnd, column);
+	return SendMessageW(t->hwnd, LVM_GETCOLUMNWIDTH, (WPARAM) column, 0);
 }
 
 void uiTableColumnSetWidth(uiTable *t, int column, int width)
 {
-	ListView_SetColumnWidth(t->hwnd, column, width);
+	SendMessageW(t->hwnd, LVM_SETCOLUMNWIDTH, (WPARAM) column, (LPARAM) width);
 }

--- a/windows/table.cpp
+++ b/windows/table.cpp
@@ -585,3 +585,13 @@ uiTable *uiNewTable(uiTableParams *p)
 
 	return t;
 }
+
+int uiTableColumnWidth(uiTable *t, int column)
+{
+	return ListView_GetColumnWidth(t->hwnd, column);
+}
+
+void uiTableColumnSetWidth(uiTable *t, int column, int width)
+{
+	ListView_SetColumnWidth(t->hwnd, column, width);
+}

--- a/windows/table.cpp
+++ b/windows/table.cpp
@@ -593,5 +593,8 @@ int uiTableColumnWidth(uiTable *t, int column)
 
 void uiTableColumnSetWidth(uiTable *t, int column, int width)
 {
+	if (width == -1)
+		width = LVSCW_AUTOSIZE_USEHEADER;
+
 	SendMessageW(t->hwnd, LVM_SETCOLUMNWIDTH, (WPARAM) column, (LPARAM) width);
 }


### PR DESCRIPTION
Old PR [libui#514](https://github.com/andlabs/libui/pull/514)

Proposal to add API functions to get and set table column widths:
```c
int uiTableColumnWidth(uiTable *t, int column);
void uiTableColumnSetWidth(uiTable *t, int column, int width);
```
Same as in #24 we need a way to identify columns. I used the same mechanism of identifying columns by index position when added for the time being. 

Implementations provided for all platforms (darwin, unix, windows) with a test bed in page16.