### PR TITLE
[Old PR libui#516] Add new API function to set a table row double click callback.

### DIFF
--- a/darwin/table.h
+++ b/darwin/table.h
@@ -18,6 +18,8 @@ struct uiTable {
 	uiTableModel *m;
 	void (*headerOnClicked)(uiTable *, int, void *);
 	void *headerOnClickedData;
+	void (*onRowDoubleClicked)(uiTable *, int, void *);
+	void *onRowDoubleClickedData;
 };
 
 // tablecolumn.m

--- a/darwin/table.m
+++ b/darwin/table.m
@@ -19,6 +19,7 @@
 - (id)initWithFrame:(NSRect)r uiprivT:(uiTable *)t uiprivM:(uiTableModel *)m;
 - (uiTable *)uiTable;
 - (void)restoreHeaderView;
+- (void)onDoubleClicked:(id)sender;
 @end
 
 @implementation uiprivTableView
@@ -42,6 +43,17 @@
 - (void)restoreHeaderView
 {
 	[self setHeaderView:self->headerViewRef];
+}
+
+- (void)onDoubleClicked:(id)sender
+{
+	uiTable *t = self->uiprivT;
+	NSInteger row = [self clickedRow];
+
+	if (row < 0)
+		return;
+
+	(*(t->onRowDoubleClicked))(t, row, t->onRowDoubleClickedData);
 }
 
 // TODO is this correct for overflow scrolling?
@@ -214,6 +226,17 @@ static void defaultHeaderOnClicked(uiTable *table, int column, void *data)
 	// do nothing
 }
 
+static void defaultOnRowDoubleClicked(uiTable *table, int row, void *data)
+{
+	// do nothing
+}
+
+void uiTableOnRowDoubleClicked(uiTable *t, void (*f)(uiTable *, int, void *), void *data)
+{
+	t->onRowDoubleClicked = f;
+	t->onRowDoubleClickedData = data;
+}
+
 uiTable *uiNewTable(uiTableParams *p)
 {
 	uiTable *t;
@@ -241,6 +264,9 @@ uiTable *uiNewTable(uiTableParams *p)
 	[t->tv setGridStyleMask:NSTableViewGridNone];
 	[t->tv setAllowsTypeSelect:YES];
 	// TODO floatsGroupRows — do we even allow group rows?
+
+	uiTableOnRowDoubleClicked(t, defaultOnRowDoubleClicked, NULL);
+	[t->tv setDoubleAction: @selector(onDoubleClicked:)];
 
 	memset(&sp, 0, sizeof (uiprivScrollViewCreateParams));
 	sp.DocumentView = t->tv;

--- a/test/page16.c
+++ b/test/page16.c
@@ -119,6 +119,15 @@ static void changedColumnWidth(uiSpinbox *s, void *data)
 	uiTableColumnSetWidth(t, uiSpinboxValue(columnID), uiSpinboxValue(columnWidth));
 }
 
+uiLabel *lblRowDoubleClicked;
+static void onRowDoubleClicked(uiTable *table, int row, void *data)
+{
+	char str[128];
+
+	sprintf(str, "Double clicked row %d", row);
+	uiLabelSetText(lblRowDoubleClicked, str);
+}
+
 static uiTableModel *m;
 
 static void headerOnClicked(uiTable *t, int col, void *data)
@@ -140,6 +149,7 @@ uiBox *makePage16(void)
 {
 	uiBox *page16;
 	uiBox *controls;
+	uiBox *stats;
 	uiCheckbox *headerVisible;
 	uiTable *t;
 	uiTableParams p;
@@ -211,6 +221,15 @@ uiBox *makePage16(void)
 
 	uiSpinboxOnChanged(columnID, changedColumnID, t);
 	uiSpinboxOnChanged(columnWidth, changedColumnWidth, t);
+
+	stats = newHorizontalBox();
+	uiBoxSetPadded(stats, 1);
+	uiBoxAppend(page16, uiControl(stats), 0);
+
+	lblRowDoubleClicked = uiNewLabel("Double clicked row -");
+	uiBoxAppend(stats, uiControl(lblRowDoubleClicked), 0);
+
+	uiTableOnRowDoubleClicked(t, onRowDoubleClicked, NULL);
 
 	return page16;
 }

--- a/ui.h
+++ b/ui.h
@@ -3732,6 +3732,24 @@ _UI_EXTERN void uiTableHeaderSetVisible(uiTable *t, int visible);
  */
 _UI_EXTERN uiTable *uiNewTable(uiTableParams *params);
 
+
+/**
+ * Registers a callback for when the user double clicks a table row.
+ *
+ * @param t uiTable instance.
+ * @param f Callback function.\n
+ *          @p sender Back reference to the instance that triggered the callback.\n
+ *          @p row Row index that was clicked.\n
+ *          @p senderData User data registered with the sender instance.
+ * @param data User data to be passed to the callback.
+ *
+ * @note Only one callback can be registered at a time.
+ * @memberof uiTable
+ */
+_UI_EXTERN void uiTableOnRowDoubleClicked(uiTable *t,
+	void (*f)(uiTable *t, int row, void *data),
+	void *data);
+
 /**
  * Sets the column's sort indicator displayed in the table header.
  *

--- a/unix/table.c
+++ b/unix/table.c
@@ -20,6 +20,8 @@ struct uiTable {
 	guint indeterminateTimer;
 	void (*headerOnClicked)(uiTable *, int, void *);
 	void *headerOnClickedData;
+	void (*onRowDoubleClicked)(uiTable *, int, void *);
+	void *onRowDoubleClickedData;
 };
 
 /*
@@ -563,6 +565,25 @@ static void uiTableDestroy(uiControl *c)
 	uiFreeControl(uiControl(t));
 }
 
+static void onRowDoubleClicked(GtkTreeView *tv, GtkTreePath *path, GtkTreeViewColumn *col, gpointer data)
+{
+	uiTable *t = uiTable(data);
+	gint row = gtk_tree_path_get_indices(path)[0];
+
+	(*(t->onRowDoubleClicked))(t, row, t->onRowDoubleClickedData);
+}
+
+static void defaultOnRowDoubleClicked(uiTable *table, int row, void *data)
+{
+	// do nothing
+}
+
+void uiTableOnRowDoubleClicked(uiTable *t, void (*f)(uiTable *, int, void *), void *data)
+{
+	t->onRowDoubleClicked = f;
+	t->onRowDoubleClickedData = data;
+}
+
 uiTable *uiNewTable(uiTableParams *p)
 {
 	uiTable *t;
@@ -580,7 +601,10 @@ uiTable *uiNewTable(uiTableParams *p)
 
 	t->treeWidget = gtk_tree_view_new_with_model(GTK_TREE_MODEL(t->model));
 	t->tv = GTK_TREE_VIEW(t->treeWidget);
+
 	// TODO set up t->tv
+	uiTableOnRowDoubleClicked(t, defaultOnRowDoubleClicked, NULL);
+	g_signal_connect(t->tv, "row-activated", G_CALLBACK(onRowDoubleClicked), t);
 
 	gtk_container_add(t->scontainer, t->treeWidget);
 	// and make the tree view visible; only the scrolled window's visibility is controlled by libui

--- a/windows/table.cpp
+++ b/windows/table.cpp
@@ -59,6 +59,17 @@ void uiTableModelRowDeleted(uiTableModel *m, int oldIndex)
 	}
 }
 
+static void defaultOnRowDoubleClicked(uiTable *table, int row, void *data)
+{
+	// do nothing
+}
+
+void uiTableOnRowDoubleClicked(uiTable *t, void (*f)(uiTable *, int, void *), void *data)
+{
+	t->onRowDoubleClicked = f;
+	t->onRowDoubleClickedData = data;
+}
+
 uiTableModelHandler *uiprivTableModelHandler(uiTableModel *m)
 {
 	return m->mh;
@@ -311,6 +322,15 @@ static BOOL onWM_NOTIFY(uiControl *c, HWND hwnd, NMHDR *nmhdr, LRESULT *lResult)
 		}
 		return TRUE;
 #endif
+	case NM_DBLCLK:
+		{
+			LVHITTESTINFO ht = {};
+			ht.pt = ((NMITEMACTIVATE *)nmhdr)->ptAction;
+			if (SendMessageW(t->hwnd, LVM_SUBITEMHITTEST, 0, (LPARAM) &ht) == -1)
+				return FALSE;
+			(*(t->onRowDoubleClicked))(t, ht.iItem, t->onRowDoubleClickedData);
+			return TRUE;
+		}
 	case LVN_ITEMCHANGED:
 		{
 			NMLISTVIEW *nm = (NMLISTVIEW *) nmhdr;
@@ -582,6 +602,8 @@ uiTable *uiNewTable(uiTableParams *p)
 	t->indeterminatePositions = new std::map<std::pair<int, int>, LONG>;
 	if (SetWindowSubclass(t->hwnd, tableSubProc, 0, (DWORD_PTR) t) == FALSE)
 		logLastError(L"SetWindowSubclass()");
+
+	uiTableOnRowDoubleClicked(t, defaultOnRowDoubleClicked, NULL);
 
 	return t;
 }

--- a/windows/table.hpp
+++ b/windows/table.hpp
@@ -44,6 +44,8 @@ struct uiTable {
 	int editedSubitem;
 	void (*headerOnClicked)(uiTable *, int, void *);
 	void *headerOnClickedData;
+	void (*onRowDoubleClicked)(uiTable *, int, void *);
+	void *onRowDoubleClickedData;
 };
 extern int uiprivTableProgress(uiTable *t, int item, int subitem, int modelColumn, LONG *pos);
 


### PR DESCRIPTION
Old PR [libui#516](https://github.com/andlabs/libui/pull/516)

Proposal to add a new API function to set a callback for when a user double clicks a table row.
```c
void uiTableOnRowDoubleClicked(uiTable *t, void (*f)(uiTable *t, int row, void *data), void *data);
```

Implementations provided for darwin, unix, and windows. A small sample usage is provided in page16.

Only thing I'm not quite sure about is the naming. Alternatives would be `uiTableRowOnDoubleClicked` or instead of *DoubleClicked* use *Activated* if we should ever want to support single click activation and disable row selection?