### PR TITLE
[Linux+Windows] allow dialogs without a parent window.

### DIFF
--- a/unix/stddialogs.c
+++ b/unix/stddialogs.c
@@ -4,7 +4,7 @@
 // LONGTERM figure out why, and describe, that this is the desired behavior
 // LONGTERM also point out that font and color buttons also work like this
 
-#define windowWindow(w) (GTK_WINDOW(uiControlHandle(uiControl(w))))
+#define windowWindow(w) ((w) ? (GTK_WINDOW(uiControlHandle(uiControl(w)))) : NULL)
 
 static char *filedialog(GtkWindow *parent, GtkFileChooserAction mode, const gchar *confirm)
 {

--- a/windows/stddialogs.cpp
+++ b/windows/stddialogs.cpp
@@ -14,7 +14,7 @@
 // - when a dialog is active, tab navigation in other windows stops working
 // - when adding uiOpenFolder(), use IFileDialog as well - https://msdn.microsoft.com/en-us/library/windows/desktop/bb762115%28v=vs.85%29.aspx
 
-#define windowHWND(w) ((HWND) uiControlHandle(uiControl(w)))
+#define windowHWND(w) (w ? (HWND)uiControlHandle(uiControl(w)) : NULL)
 
 char *commonItemDialog(HWND parent, REFCLSID clsid, REFIID iid, FILEOPENDIALOGOPTIONS optsadd)
 {


### PR DESCRIPTION
Part of andlabs/libui#375
- untested
- macOS missed