### PR TITLE
[Old PR libui#497] Set column title on OS X 10.9.

### DIFF
--- a/darwin/tablecolumn.m
+++ b/darwin/tablecolumn.m
@@ -32,6 +32,15 @@
 	return nil;			// appease compiler
 }
 
+static void setTitle(uiprivTableColumn *col, NSString *str)
+{
+	if ([col respondsToSelector:@selector(setTitle:)]) {
+		[col setTitle:str];
+	} else {
+		[[col headerCell] setStringValue:str];
+	}
+}
+
 @end
 
 struct textColumnCreateParams {
@@ -596,7 +605,7 @@ void uiTableAppendTextColumn(uiTable *t, const char *name, int textModelColumn, 
 	ident = [@([[t->tv tableColumns] count]) stringValue];
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	[col setTitle:str];
+	setTitle(col, str);
 	[t->tv addTableColumn:col];
 }
 
@@ -617,7 +626,7 @@ void uiTableAppendImageColumn(uiTable *t, const char *name, int imageModelColumn
 	ident = [@([[t->tv tableColumns] count]) stringValue];
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	[col setTitle:str];
+	setTitle(col, str);
 	[t->tv addTableColumn:col];
 }
 
@@ -646,7 +655,7 @@ void uiTableAppendImageTextColumn(uiTable *t, const char *name, int imageModelCo
 	ident = [@([[t->tv tableColumns] count]) stringValue];
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	[col setTitle:str];
+	setTitle(col, str);
 	[t->tv addTableColumn:col];
 }
 
@@ -668,7 +677,7 @@ void uiTableAppendCheckboxColumn(uiTable *t, const char *name, int checkboxModel
 	ident = [@([[t->tv tableColumns] count]) stringValue];
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	[col setTitle:str];
+	setTitle(col, str);
 	[t->tv addTableColumn:col];
 }
 
@@ -698,7 +707,7 @@ void uiTableAppendCheckboxTextColumn(uiTable *t, const char *name, int checkboxM
 	ident = [@([[t->tv tableColumns] count]) stringValue];
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
-	[col setTitle:str];
+	setTitle(col, str);
 	[t->tv addTableColumn:col];
 }
 
@@ -711,7 +720,7 @@ void uiTableAppendProgressBarColumn(uiTable *t, const char *name, int progressMo
 	ident = [@([[t->tv tableColumns] count]) stringValue];
 	col = [[uiprivProgressBarTableColumn alloc] initWithIdentifier:ident table:t model:t->m modelColumn:progressModelColumn];
 	str = [NSString stringWithUTF8String:name];
-	[col setTitle:str];
+	setTitle(col, str);
 	[t->tv addTableColumn:col];
 }
 
@@ -724,6 +733,6 @@ void uiTableAppendButtonColumn(uiTable *t, const char *name, int buttonModelColu
 	ident = [@([[t->tv tableColumns] count]) stringValue];
 	col = [[uiprivButtonTableColumn alloc] initWithIdentifier:ident table:t model:t->m modelColumn:buttonModelColumn editableColumn:buttonClickableModelColumn];
 	str = [NSString stringWithUTF8String:name];
-	[col setTitle:str];
+	setTitle(col, str);
 	[t->tv addTableColumn:col];
 }

--- a/darwin/tablecolumn.m
+++ b/darwin/tablecolumn.m
@@ -32,6 +32,7 @@
 	return nil;			// appease compiler
 }
 
+// Fallback for macOS < 10.10
 static void setTitle(uiprivTableColumn *col, NSString *str)
 {
 	if ([col respondsToSelector:@selector(setTitle:)]) {


### PR DESCRIPTION
Old PR [libui#497](https://github.com/andlabs/libui/pull/497)

As can seen in the description of the original PR [the setTitle function is only available from macOS 10.10 onwards](https://developer.apple.com/documentation/appkit/nstablecolumn/1526875-title?language=objc).

The README states support for macOS 10.8.

I do not have a system that old, but I just tested the `[col headerCell] setStringValue:str]` branch and it works fine.

Only concert could be, why two branches, if the old way still works on newer systems?