### PR TITLE
Test big tables

### DIFF
--- a/test/page16.c
+++ b/test/page16.c
@@ -1,6 +1,8 @@
 // 21 june 2016
 #include "test.h"
 
+#define MODEL_NUM_ROWS 100000
+
 static uiTableModelHandler mh;
 
 static int modelNumColumns(uiTableModelHandler *mh, uiTableModel *m)
@@ -21,13 +23,13 @@ static uiTableValueType modelColumnType(uiTableModelHandler *mh, uiTableModel *m
 
 static int modelNumRows(uiTableModelHandler *mh, uiTableModel *m)
 {
-	return 15;
+	return MODEL_NUM_ROWS;
 }
 
 static uiImage *img[2];
 static char row9text[1024];
 static int yellowRow = -1;
-static int checkStates[15];
+static int checkStates[MODEL_NUM_ROWS];
 
 static uiTableValue *modelCellValue(uiTableModelHandler *mh, uiTableModel *m, int row, int col)
 {
@@ -139,8 +141,6 @@ uiBox *makePage16(void)
 	appendImageNamed(img[1], "tango-icon-theme-0.8.90_32x32_x-office-spreadsheet.png");
 
 	strcpy(row9text, "Part");
-
-	memset(checkStates, 0, 15 * sizeof (int));
 
 	page16 = newVerticalBox();
 	controls = newHorizontalBox();

--- a/test/page17.c
+++ b/test/page17.c
@@ -154,7 +154,7 @@ static void populateData(void)
 	int row;
 	char text[ROWXX_SIZE];
 
-	data.numRows = 10;
+	data.numRows = 100000;
 	data.rows = malloc(data.numRows * sizeof(*data.rows));
 	assert(data.rows != NULL);
 


### PR DESCRIPTION
As mentioned in another comment I believe we should ensure adequate performance on big tables.

To do so I increased the row count to 100k on page 16 & 17.

Testing things, unix and darwin performance are great and windows is ok (tested on a windows 7 vm).

Sadly wine performance is abysmal (deleting rows) but that is clearly an upstream issue that doesn't concern us. It just means I'll have to do more of my testing in a windows vm :|