### PR TITLE
darwin: Set minimum column width to 0 to match unix and windows.

### DIFF
--- a/darwin/tablecolumn.m
+++ b/darwin/tablecolumn.m
@@ -597,6 +597,7 @@ void uiTableAppendTextColumn(uiTable *t, const char *name, int textModelColumn, 
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
 	[col setTitle:str];
+	[col setMinWidth: 0];
 	[t->tv addTableColumn:col];
 }
 
@@ -618,6 +619,7 @@ void uiTableAppendImageColumn(uiTable *t, const char *name, int imageModelColumn
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
 	[col setTitle:str];
+	[col setMinWidth: 0];
 	[t->tv addTableColumn:col];
 }
 
@@ -647,6 +649,7 @@ void uiTableAppendImageTextColumn(uiTable *t, const char *name, int imageModelCo
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
 	[col setTitle:str];
+	[col setMinWidth: 0];
 	[t->tv addTableColumn:col];
 }
 
@@ -669,6 +672,7 @@ void uiTableAppendCheckboxColumn(uiTable *t, const char *name, int checkboxModel
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
 	[col setTitle:str];
+	[col setMinWidth: 0];
 	[t->tv addTableColumn:col];
 }
 
@@ -699,6 +703,7 @@ void uiTableAppendCheckboxTextColumn(uiTable *t, const char *name, int checkboxM
 	col = [[uiprivTextImageCheckboxTableColumn alloc] initWithIdentifier:ident params:&p];
 	str = [NSString stringWithUTF8String:name];
 	[col setTitle:str];
+	[col setMinWidth: 0];
 	[t->tv addTableColumn:col];
 }
 
@@ -712,6 +717,7 @@ void uiTableAppendProgressBarColumn(uiTable *t, const char *name, int progressMo
 	col = [[uiprivProgressBarTableColumn alloc] initWithIdentifier:ident table:t model:t->m modelColumn:progressModelColumn];
 	str = [NSString stringWithUTF8String:name];
 	[col setTitle:str];
+	[col setMinWidth: 0];
 	[t->tv addTableColumn:col];
 }
 
@@ -725,5 +731,6 @@ void uiTableAppendButtonColumn(uiTable *t, const char *name, int buttonModelColu
 	col = [[uiprivButtonTableColumn alloc] initWithIdentifier:ident table:t model:t->m modelColumn:buttonModelColumn editableColumn:buttonClickableModelColumn];
 	str = [NSString stringWithUTF8String:name];
 	[col setTitle:str];
+	[col setMinWidth: 0];
 	[t->tv addTableColumn:col];
 }


### PR DESCRIPTION
This is an attempt at more consistency between the platforms:

Unix and windows columns can manipulated by the user to have 0
width. The default on darwin is 10. This commit changes the minimum
width to 0 to match the other platforms.

Note: zero width on darwin still retains a significant amount of
space in the header compared to unix and windows. Still maybe better
than the default width of 10?