### PR TITLE
Table selection API

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -10,6 +10,7 @@ libui_sources += [
 	'common/matrix.c',
 	'common/opentype.c',
 	'common/shouldquit.c',
+	'common/table.c',
 	'common/tablemodel.c',
 	'common/tablevalue.c',
 	'common/userbugs.c',

--- a/common/table.c
+++ b/common/table.c
@@ -1,0 +1,10 @@
+#include "../ui.h"
+#include "uipriv.h"
+
+void uiFreeTableSelection(uiTableSelection *s)
+{
+	if (s->Rows != NULL)
+		uiprivFree(s->Rows);
+	uiprivFree(s);
+}
+

--- a/darwin/table.h
+++ b/darwin/table.h
@@ -22,6 +22,8 @@ struct uiTable {
 	void *onRowClickedData;
 	void (*onRowDoubleClicked)(uiTable *, int, void *);
 	void *onRowDoubleClickedData;
+	void (*onSelectionChanged)(uiTable *, void *);
+	void *onSelectionChangedData;
 };
 
 // tablecolumn.m

--- a/ui.h
+++ b/ui.h
@@ -3842,6 +3842,115 @@ _UI_EXTERN int uiTableColumnWidth(uiTable *t, int column);
  */
 _UI_EXTERN void uiTableColumnSetWidth(uiTable *t, int column, int width);
 
+/**
+ * Table selection modes.
+ *
+ * Table selection that enforce how a user can interact with a table.
+ *
+ * @warning An empty table selection is a valid state for any selection mode.
+ *          This is in fact the default upon table creation and can otherwise
+ *          triggered through operations such as row deletion.
+ *
+ * @enum uiTableSelectionMode
+ * @ingroup table
+ */
+_UI_ENUM(uiTableSelectionMode) {
+	/**
+	 * Allow no row selection.
+	 *
+	 * @warning This mode disables all editing of text columns. Buttons
+	 * and checkboxes keep working though.
+	 */
+        uiTableSelectionModeNone,
+        uiTableSelectionModeZeroOrOne,  //!< Allow zero or one row to be selected.
+        uiTableSelectionModeOne,        //!< Allow for exactly one row to be selected.
+        uiTableSelectionModeZeroOrMany, //!< Allow zero or many (multiple) rows to be selected.
+};
+
+/**
+ * Returns the table selection mode.
+ *
+ * @param t uiTable instance.
+ * @returns The table selection mode. [Default `uiTableSelectionModeZeroOrOne`]
+ *
+ * @memberof uiTable
+ */
+_UI_EXTERN uiTableSelectionMode uiTableGetSelectionMode(uiTable *t);
+
+/**
+ * Sets the table selection mode.
+ *
+ * @param t uiTable instance.
+ * @param mode Table selection mode to set.
+ *
+ * @warning All rows will be deselected if the existing selection is illegal
+ *          in the new selection mode.
+ * @memberof uiTable
+ */
+_UI_EXTERN void uiTableSetSelectionMode(uiTable *t, uiTableSelectionMode mode);
+
+/**
+ * Registers a callback for when the table selection changed.
+ *
+ * @param t uiTable instance.
+ * @param f Callback function.\n
+ *          @p sender Back reference to the instance that triggered the callback.\n
+ *          @p senderData User data registered with the sender instance.
+ * @param data User data to be passed to the callback.
+ *
+ * @note The callback is not triggered when calling uiTableSetSelection() or
+ *       when needing to clear the selection on uiTableSetSelectionMode().
+ * @note Only one callback can be registered at a time.
+ * @memberof uiTable
+ */
+_UI_EXTERN void uiTableOnSelectionChanged(uiTable *t, void (*f)(uiTable *t, void *data), void *data);
+
+/**
+ * Holds an array of selected row indices for a table.
+ *
+ * @struct uiTableSelection
+ * @ingroup table
+ */
+typedef struct uiTableSelection uiTableSelection;
+struct uiTableSelection
+{
+	int NumRows; //!< Number of selected rows.
+	int *Rows;   //!< Array containing selected row indices, NULL on empty selection.
+};
+
+/**
+ * Returns the current table selection.
+ *
+ * @param t uiTable instance.
+ * @returns The number of selected rows and corresponding row indices.\n
+ *          Data is owned by the caller, make sure to call uiFreeTableSelection().
+ *
+ * @note For empty selections the `Rows` pointer will be NULL.
+ * @memberof uiTable
+ */
+_UI_EXTERN uiTableSelection* uiTableGetSelection(uiTable *t);
+
+/**
+ * Sets the current table selection clearing any previous selection.
+ *
+ * @param t uiTable instance.
+ * @param sel Table selection.\n
+ *            Data is owned by the caller.
+ *
+ * @note Selecting more rows than the selection mode allows for results in nothing happening.
+ * @note For empty selections the Rows pointer is never accessed.
+ * @memberof uiTable
+ */
+_UI_EXTERN void uiTableSetSelection(uiTable *t, uiTableSelection *sel);
+
+/**
+ * Frees the given uiTableSelection and all it's resources.
+ *
+ * @param s uiTableSelection instance.
+ * @memberof uiTableSelection
+ */
+_UI_EXTERN void uiFreeTableSelection(uiTableSelection* s);
+
 #ifdef __cplusplus
 }
 #endif

--- a/windows/table.hpp
+++ b/windows/table.hpp
@@ -42,12 +42,22 @@ struct uiTable {
 	HWND edit;
 	int editedItem;
 	int editedSubitem;
+	uiTableSelectionMode selectionMode;
+	BOOL maskOnSelectionChanged;
+	// Cache last focused item to signal selection changes
+	int lastFocusedItem;
+	// Cache if last focused item is selected to signal selection changes
+	BOOL lastFocusedItemIsSelected;
+	// Cache last number of selected items to signal selection changes
+	int lastNumSelected;
 	void (*headerOnClicked)(uiTable *, int, void *);
 	void *headerOnClickedData;
 	void (*onRowClicked)(uiTable *, int, void *);
 	void *onRowClickedData;
 	void (*onRowDoubleClicked)(uiTable *, int, void *);
 	void *onRowDoubleClickedData;
+	void (*onSelectionChanged)(uiTable *, void *);
+	void *onSelectionChangedData;
 };
 extern int uiprivTableProgress(uiTable *t, int item, int subitem, int modelColumn, LONG *pos);
 


### PR DESCRIPTION
This is an effort to provide a table selection API as was suggested in [libui#413](https://github.com/andlabs/libui/pull/413).

I have made some alterations to the original proposal.

This introduces 5 different table selection modes:
```
uiTableSelectionModeNone,       //!< Allow no row selection.                                
uiTableSelectionModeZeroOrOne,  //!< Allow zero or one row to be selected.                  
uiTableSelectionModeOne,        //!< Allow for exactly one row to be selected.              
uiTableSelectionModeZeroOrMany, //!< Allow zero or many (multiple) rows to be selected. 
```

With a get/set function:
```c
uiTableSelectionMode uiTableGetSelectionMode(uiTable *t);
void uiTableSetSelectionMode(uiTable *t, uiTableSelectionMode mode);
```

And then three functions to set a selection changed callback and get/free the actual selection:
```c
void uiTableOnSelectionChanged(uiTable *t, void (*f)(uiTable *t, void *data), void *data);
uiTableSelection* uiTableGetSelection(uiTable *t);
void uiTableSetSelection(uiTable *t, uiTableSelection *selection);
void uiFreeTableSelection(uiTableSelection* s);
```

uiTableSelection struct:
```c
struct uiTableSelection
{
    int NumRows;
    int *Rows;
};
```

I did some testing with the big tables (100k rows). Selecting all rows at once and having the tester print the rows on the terminal still has IMO very acceptable performance. Only minimal lag on my system.
An iterator style API would be nice in the future though. 

~~There is still one inconsistency across platforms remaining as far as I can tell:~~
~~Windows and unix both emit a selection changed when clicking on an already selected row on `uiTableSelectionModeZeroOrMany`, darwin will not. ~~Should be try to suppress this?~~ I've managed to suppress this for all other modes, for multi select I fear we might need to cache the entire selection and compare possibly on each selection change. Not sure what that would mean for performance.~~

~~All other edge cases _should_ be documented in the API docs.~~

Otherwise this works for me on all officially supported platforms. Wine sadly does not work, ~~see [upstream bug report](https://bugs.winehq.org/show_bug.cgi?id=52534). I've sent in patches for fixing wine, so far no luck.~~

I've kept my commits intact, if need be I can squash.

~~There are a few things I am not quite happy about:~~
* ~~Inefficiencies in the unix & darwin code. We need to iterate over the selection multiple times to convert formats~~
* ~~Should `uiTableSelectionCurrentSelection` return a value to indicate `malloc` errors? `assert` is not acceptable. Or is the current note in `ui.h` sufficient, requiring users to check BOTH `rows != NULL` and `numRows > 0`?~~

~~My question is: are these inefficiencies acceptable? I was wondering if it would be possible to provide some type of iterator API? I am however not sure if it is even possible or if it would really lead to any significant gains.~~

~~Then there seems to be a bug on windows (win7). Can anybody reproduce? Go to tester, page16, click `Multiple Selection`, try to edit a cell in the editable column. On many occasions the cell will loose focus by itself and editing will be stopped. Interestingly enough this does not happen on wine. Can anybody reproduce this on newer windows versions?~~

~~Edit: Windows default behavior when clicking an already selected/focused row seems to be: Send a deselect signal to for all items `nm->iItem == -1` and then send another select signal for the row that was already selected/focused. I replicated this with the [windows sample virtual list](https://github.com/szanni/Windows-classic-samples/tree/main/Samples/Win7Samples/winui/controls/common/vlistvw)~~