### PR TITLE
Remove redundant uiUnixStrdupText calls.

### DIFF
--- a/unix/editablecombo.c
+++ b/unix/editablecombo.c
@@ -33,14 +33,7 @@ void uiEditableComboboxAppend(uiEditableCombobox *c, const char *text)
 
 char *uiEditableComboboxText(uiEditableCombobox *c)
 {
-	char *s;
-	char *out;
-
-	s = gtk_combo_box_text_get_active_text(c->comboboxText);
-	// s will always be non-NULL in the case of a combobox with an entry (according to the source code)
-	out = uiUnixStrdupText(s);
-	g_free(s);
-	return out;
+	return gtk_combo_box_text_get_active_text(c->comboboxText);
 }
 
 void uiEditableComboboxSetText(uiEditableCombobox *c, const char *text)

--- a/unix/multilineentry.c
+++ b/unix/multilineentry.c
@@ -33,15 +33,11 @@ static void defaultOnChanged(uiMultilineEntry *e, void *data)
 char *uiMultilineEntryText(uiMultilineEntry *e)
 {
 	GtkTextIter start, end;
-	char *tret, *out;
 
 	gtk_text_buffer_get_start_iter(e->textbuf, &start);
 	gtk_text_buffer_get_end_iter(e->textbuf, &end);
-	tret = gtk_text_buffer_get_text(e->textbuf, &start, &end, TRUE);
-	// theoretically we could just return tret because uiUnixStrdupText() is just g_strdup(), but if that ever changes we can't, so let's do it this way to be safe
-	out = uiUnixStrdupText(tret);
-	g_free(tret);
-	return out;
+
+	return gtk_text_buffer_get_text(e->textbuf, &start, &end, TRUE);
 }
 
 void uiMultilineEntrySetText(uiMultilineEntry *e, const char *text)


### PR DESCRIPTION
As was highlighted in #75 there might be some more nonsensical use of `uiUnixStrdupText()`.

This PR removes the future proofing for the imaginary future when the implementation of `uiUnixStrdupText()` would change.

I am honestly not quite sure what the original intent was, why not use `g_strdup` directly? Going through the commit logs, I could not find any explanation. 