### PR TITLE
unix: Fix some of the easy to fix compile time warnings.

### DIFF
--- a/common/attribute.c
+++ b/common/attribute.c
@@ -62,7 +62,8 @@ static void destroy(uiAttribute *a)
 void uiprivAttributeRelease(uiAttribute *a)
 {
 	if (a->ownedByUser)
-		/* TODO implementation bug: we can't release an attribute we don't own */;
+		uiprivImplBug("Can't release attribute we don't own %p", a);
+
 	a->refcount--;
 	if (a->refcount == 0)
 		destroy(a);
@@ -71,7 +72,8 @@ void uiprivAttributeRelease(uiAttribute *a)
 void uiFreeAttribute(uiAttribute *a)
 {
 	if (!a->ownedByUser)
-		/* TODO user bug: you can't free an attribute you don't own */;
+		uiprivImplBug("Can't release attribute we don't own %p", a);
+
 	destroy(a);
 }
 

--- a/test/main.c
+++ b/test/main.c
@@ -46,8 +46,8 @@ int main(int argc, char *argv[])
 	const char *err;
 	uiWindow *w;
 	uiBox *page2, *page3, *page4, *page5;
-	uiBox *page6, *page7, *page8, *page9, *page10;
-	uiBox *page11, *page12, *page13;
+	uiBox *page6, *page7;
+	uiBox *page12, *page13;
 	uiTab *page14;
 	uiBox *page15;
 	uiBox *page16;

--- a/test/page13.c
+++ b/test/page13.c
@@ -52,9 +52,14 @@ static void openTestWindow(uiBox *(*mkf)(void))
 	uiControlShow(uiControl(w));
 }
 
-static void buttonClicked(uiButton *b, void *data)
+static void hButtonClicked(uiButton *b, void *data)
 {
-	openTestWindow((uiBox *(*)(void)) data);
+	openTestWindow(uiNewHorizontalBox);
+}
+
+static void vButtonClicked(uiButton *b, void *data)
+{
+	openTestWindow(uiNewVerticalBox);
 }
 
 static void entryChanged(uiEntry *e, void *data)
@@ -119,11 +124,11 @@ uiBox *makePage13(void)
 	uiBoxAppend(page13, uiControl(rb), 0);
 
 	b = uiNewButton("Horizontal");
-	uiButtonOnClicked(b, buttonClicked, uiNewHorizontalBox);
+	uiButtonOnClicked(b, hButtonClicked, NULL);
 	uiBoxAppend(page13, uiControl(b), 0);
 
 	b = uiNewButton("Vertical");
-	uiButtonOnClicked(b, buttonClicked, uiNewVerticalBox);
+	uiButtonOnClicked(b, vButtonClicked, NULL);
 	uiBoxAppend(page13, uiControl(b), 0);
 
 	f = newForm();

--- a/unix/alloc.c
+++ b/unix/alloc.c
@@ -24,7 +24,7 @@ static void uninitComplain(gpointer ptr, gpointer data)
 	char *str2;
 
 	if (*str == NULL)
-		*str = g_strdup_printf("");
+		*str = g_strdup("");
 	str2 = g_strdup_printf("%s%p %s\n", *str, ptr, *TYPE(ptr));
 	g_free(*str);
 	*str = str2;

--- a/unix/cellrendererbutton.c
+++ b/unix/cellrendererbutton.c
@@ -223,7 +223,6 @@ static void cellRendererButton_render(GtkCellRenderer *r, cairo_t *cr, GtkWidget
 {
 	cellRendererButton *c = cellRendererButton(r);
 	gint xpad, ypad;
-	GdkRectangle alignedArea;
 	gint xoff, yoff;
 	GtkStyleContext *context;
 	PangoLayout *layout;

--- a/unix/image.c
+++ b/unix/image.c
@@ -41,8 +41,9 @@ void uiImageAppend(uiImage *i, void *pixels, int pixelWidth, int pixelHeight, in
 	// note that this is native-endian
 	cs = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
 		pixelWidth, pixelHeight);
-	if (cairo_surface_status(cs) != CAIRO_STATUS_SUCCESS)
-		/* TODO */;
+	if (cairo_surface_status(cs) != CAIRO_STATUS_SUCCESS) {
+		/* TODO */
+	}
 	cairo_surface_flush(cs);
 
 	pix = (uint8_t *) pixels;


### PR DESCRIPTION
This is a first step towards removing all compile time warnings, see #84.

This PR addresses easy to fix issues. More work is still needed - those patches might need some discussion/more thorough review though, hence separate PRs.