### PR TITLE
[All Platforms] uiWindow: add event uiWindowOnFocusChanged() / uiWindowFocused()

### DIFF
--- a/darwin/window.m
+++ b/darwin/window.m
@@ -14,9 +14,9 @@ struct uiWindow {
 	void (*onContentSizeChanged)(uiWindow *, void *);
 	void *onContentSizeChangedData;
 	void (*onGetFocus)(uiWindow*, void *);
-	void (*onGetFocusData);
+	void *onGetFocusData;
 	void (*onLoseFocus)(uiWindow*, void *);
-	void (*onLoseFocusData);
+	void *onLoseFocusData;
 	BOOL suppressSizeChanged;
 	int fullscreen;
 	int borderless;

--- a/test/page5.c
+++ b/test/page5.c
@@ -68,12 +68,12 @@ static void msgBoxError(uiButton *b, void *data)
 
 void onGetFocus(uiWindow *w, void *data)
 {
-	uiCheckboxSetChecked(uiCheckbox(data), 1);
+	uiLabelSetText(uiLabel(data), "Window is focused");
 }
 
 void onLoseFocus(uiWindow *w, void *data)
 {
-	uiCheckboxSetChecked(uiCheckbox(data), 0);
+	uiLabelSetText(uiLabel(data), "Window is not focused");
 }
 
 
@@ -84,7 +84,7 @@ uiBox *makePage5(uiWindow *pw)
 	uiBox *hbox;
 	uiButton *button;
 	uiLabel *label;
-	uiCheckbox *check;
+	uiLabel *focusLabel;
 
 	parent = pw;
 
@@ -122,11 +122,11 @@ uiBox *makePage5(uiWindow *pw)
 	uiBoxAppend(hbox, uiControl(description), 0);
 	uiBoxAppend(page5, uiControl(hbox), 0);
 
-	check = uiNewCheckbox("Window Focused");
-	uiBoxAppend(page5, uiControl(check), 0);
+	focusLabel = uiNewLabel("");
+	uiBoxAppend(page5, uiControl(focusLabel), 0);
 
-	uiWindowOnGetFocus(parent, onGetFocus, check);
-	uiWindowOnLoseFocus(parent, onLoseFocus, check);
+	uiWindowOnGetFocus(parent, onGetFocus, focusLabel);
+	uiWindowOnLoseFocus(parent, onLoseFocus, focusLabel);
 
 	return page5;
 }

--- a/test/page5.c
+++ b/test/page5.c
@@ -66,12 +66,25 @@ static void msgBoxError(uiButton *b, void *data)
 	uiFreeText(t);
 }
 
+void onGetFocus(uiWindow *w, void *data)
+{
+	uiCheckboxSetChecked(uiCheckbox(data), 1);
+}
+
+void onLoseFocus(uiWindow *w, void *data)
+{
+	uiCheckboxSetChecked(uiCheckbox(data), 0);
+}
+
+
+
 uiBox *makePage5(uiWindow *pw)
 {
 	uiBox *page5;
 	uiBox *hbox;
 	uiButton *button;
 	uiLabel *label;
+	uiCheckbox *check;
 
 	parent = pw;
 
@@ -108,6 +121,12 @@ uiBox *makePage5(uiWindow *pw)
 	uiBoxAppend(hbox, uiControl(button), 0);
 	uiBoxAppend(hbox, uiControl(description), 0);
 	uiBoxAppend(page5, uiControl(hbox), 0);
+
+	check = uiNewCheckbox("Window Focused");
+	uiBoxAppend(page5, uiControl(check), 0);
+
+	uiWindowOnGetFocus(parent, onGetFocus, check);
+	uiWindowOnLoseFocus(parent, onLoseFocus, check);
 
 	return page5;
 }

--- a/test/page5.c
+++ b/test/page5.c
@@ -66,14 +66,13 @@ static void msgBoxError(uiButton *b, void *data)
 	uiFreeText(t);
 }
 
-void onGetFocus(uiWindow *w, void *data)
+void onFocusChanged(uiWindow *w, void *data)
 {
-	uiLabelSetText(uiLabel(data), "Window is focused");
-}
-
-void onLoseFocus(uiWindow *w, void *data)
-{
-	uiLabelSetText(uiLabel(data), "Window is not focused");
+	if (uiWindowFocused(w)) {
+		uiLabelSetText(uiLabel(data), "Window is focused");
+	} else {
+		uiLabelSetText(uiLabel(data), "Window is not focused");
+	}
 }
 
 
@@ -125,8 +124,7 @@ uiBox *makePage5(uiWindow *pw)
 	focusLabel = uiNewLabel("");
 	uiBoxAppend(page5, uiControl(focusLabel), 0);
 
-	uiWindowOnGetFocus(parent, onGetFocus, focusLabel);
-	uiWindowOnLoseFocus(parent, onLoseFocus, focusLabel);
+	uiWindowOnFocusChanged(parent, onFocusChanged, focusLabel);
 
 	return page5;
 }

--- a/ui.h
+++ b/ui.h
@@ -134,8 +134,8 @@ _UI_EXTERN uiWindow *uiNewWindow(const char *title, int width, int height, int h
 
 _UI_EXTERN void uiWindowOnContentSizeChanged(uiWindow *w, void (*f)(uiWindow *, void *), void *data);
 _UI_EXTERN void uiWindowOnClosing(uiWindow *w, int (*f)(uiWindow *w, void *data), void *data);
-_UI_EXTERN void uiWindowOnGetFocus(uiWindow *w, void (*f)(uiWindow *w, void *data), void *data);
-_UI_EXTERN void uiWindowOnLoseFocus(uiWindow *w, void (*f)(uiWindow *w, void *data), void *data);
+_UI_EXTERN void uiWindowOnFocusChanged(uiWindow *w, void (*f)(uiWindow *, void *), void *data);
+_UI_EXTERN int uiWindowFocused(uiWindow *w);
 
 typedef struct uiButton uiButton;
 #define uiButton(this) ((uiButton *) (this))

--- a/ui.h
+++ b/ui.h
@@ -123,8 +123,6 @@ _UI_EXTERN void uiWindowContentSize(uiWindow *w, int *width, int *height);
 _UI_EXTERN void uiWindowSetContentSize(uiWindow *w, int width, int height);
 _UI_EXTERN int uiWindowFullscreen(uiWindow *w);
 _UI_EXTERN void uiWindowSetFullscreen(uiWindow *w, int fullscreen);
-_UI_EXTERN void uiWindowOnContentSizeChanged(uiWindow *w, void (*f)(uiWindow *, void *), void *data);
-_UI_EXTERN void uiWindowOnClosing(uiWindow *w, int (*f)(uiWindow *w, void *data), void *data);
 _UI_EXTERN int uiWindowBorderless(uiWindow *w);
 _UI_EXTERN void uiWindowSetBorderless(uiWindow *w, int borderless);
 _UI_EXTERN void uiWindowSetChild(uiWindow *w, uiControl *child);
@@ -133,6 +131,11 @@ _UI_EXTERN void uiWindowSetMargined(uiWindow *w, int margined);
 _UI_EXTERN int uiWindowResizeable(uiWindow *w);
 _UI_EXTERN void uiWindowSetResizeable(uiWindow *w, int resizeable);
 _UI_EXTERN uiWindow *uiNewWindow(const char *title, int width, int height, int hasMenubar);
+
+_UI_EXTERN void uiWindowOnContentSizeChanged(uiWindow *w, void (*f)(uiWindow *, void *), void *data);
+_UI_EXTERN void uiWindowOnClosing(uiWindow *w, int (*f)(uiWindow *w, void *data), void *data);
+_UI_EXTERN void uiWindowOnGetFocus(uiWindow *w, void (*f)(uiWindow *w, void *data), void *data);
+_UI_EXTERN void uiWindowOnLoseFocus(uiWindow *w, void (*f)(uiWindow *w, void *data), void *data);
 
 typedef struct uiButton uiButton;
 #define uiButton(this) ((uiButton *) (this))

--- a/unix/window.c
+++ b/unix/window.c
@@ -55,15 +55,15 @@ static void onSizeAllocate(GtkWidget *widget, GdkRectangle *allocation, gpointer
 static gboolean onGetFocus(GtkWidget *win, GdkEvent *e, gpointer data)
 {
 	uiWindow *w = uiWindow(data);
-	if (w->onGetFocus)
-		w->onGetFocus(w, w->onGetFocusData);
+	w->onGetFocus(w, w->onGetFocusData);
+	return FALSE;
 }
 
 static gboolean onLoseFocus(GtkWidget *win, GdkEvent *e, gpointer data)
 {
 	uiWindow *w = uiWindow(data);
-	if (w->onLoseFocus)
-		w->onLoseFocus(w, w->onLoseFocusData);
+	w->onLoseFocus(w, w->onLoseFocusData);
+	return FALSE;
 }
 
 static int defaultOnClosing(uiWindow *w, void *data)
@@ -72,6 +72,16 @@ static int defaultOnClosing(uiWindow *w, void *data)
 }
 
 static void defaultOnPositionContentSizeChanged(uiWindow *w, void *data)
+{
+	// do nothing
+}
+
+static void defaultOnGetFocus(uiWindow *w, void *data)
+{
+	// do nothing
+}
+
+static void defaultOnLoseFocus(uiWindow *w, void *data)
 {
 	// do nothing
 }
@@ -318,8 +328,8 @@ uiWindow *uiNewWindow(const char *title, int width, int height, int hasMenubar)
 	uiWindowOnClosing(w, defaultOnClosing, NULL);
 	uiWindowOnContentSizeChanged(w, defaultOnPositionContentSizeChanged, NULL);
 
-	uiWindowOnGetFocus(w, NULL, NULL);
-	uiWindowOnLoseFocus(w, NULL, NULL);
+	uiWindowOnGetFocus(w, defaultOnGetFocus, NULL);
+	uiWindowOnLoseFocus(w, defaultOnLoseFocus, NULL);
 
 	// normally it's SetParent() that does this, but we can't call SetParent() on a uiWindow
 	// TODO we really need to clean this up, especially since see uiWindowDestroy() above

--- a/windows/window.cpp
+++ b/windows/window.cpp
@@ -119,17 +119,11 @@ static LRESULT CALLBACK windowWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARA
 		return lResult;
 
 	case WM_SETFOCUS:
-		if (w->onGetFocus) {
-			w->onGetFocus(w, w->onGetFocusData);
-			return 0;
-		}
-		break;
+		w->onGetFocus(w, w->onGetFocusData);
+		return 0;
 	case WM_KILLFOCUS:
-		if (w->onLoseFocus) {
-			w->onLoseFocus(w, w->onLoseFocusData);
-			return 0;
-		}
-		break;
+		w->onLoseFocus(w, w->onLoseFocusData);
+		return 0;
 
 	case WM_PRINTCLIENT:
 		// we do no special painting; just erase the background
@@ -170,6 +164,16 @@ static int defaultOnClosing(uiWindow *w, void *data)
 }
 
 static void defaultOnPositionContentSizeChanged(uiWindow *w, void *data)
+{
+	// do nothing
+}
+
+static void defaultOnGetFocus(uiWindow *w, void *data)
+{
+	// do nothing
+}
+
+static void defaultOnLoseFocus(uiWindow *w, void *data)
 {
 	// do nothing
 }
@@ -542,8 +546,8 @@ uiWindow *uiNewWindow(const char *title, int width, int height, int hasMenubar)
 	uiWindowOnClosing(w, defaultOnClosing, NULL);
 	uiWindowOnContentSizeChanged(w, defaultOnPositionContentSizeChanged, NULL);
 
-	uiWindowOnGetFocus(w, NULL, NULL);
-	uiWindowOnLoseFocus(w, NULL, NULL);
+	uiWindowOnGetFocus(w, defaultOnGetFocus, NULL);
+	uiWindowOnLoseFocus(w, defaultOnLoseFocus, NULL);
 
 	windows[w] = true;
 	return w;

--- a/windows/window.cpp
+++ b/windows/window.cpp
@@ -10,17 +10,22 @@ struct uiWindow {
 	uiControl *child;
 	BOOL shownOnce;
 	int visible;
-	int (*onClosing)(uiWindow *, void *);
-	void *onClosingData;
 	int margined;
 	int resizeable;
 	BOOL hasMenubar;
-	void (*onContentSizeChanged)(uiWindow *, void *);
-	void *onContentSizeChangedData;
 	BOOL changingSize;
 	int fullscreen;
 	WINDOWPLACEMENT fsPrevPlacement;
 	int borderless;
+
+	int (*onClosing)(uiWindow *, void *);
+	void *onClosingData;
+	void (*onContentSizeChanged)(uiWindow *, void *);
+	void *onContentSizeChangedData;
+	void (*onGetFocus)(uiWindow *, void *);
+	void *onGetFocusData;
+	void (*onLoseFocus)(uiWindow *, void *);
+	void *onLoseFocusData;
 };
 
 // from https://msdn.microsoft.com/en-us/library/windows/desktop/dn742486.aspx#sizingandspacing
@@ -112,6 +117,20 @@ static LRESULT CALLBACK windowWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARA
 		mmi->ptMinTrackSize.x = width;
 		mmi->ptMinTrackSize.y = height;
 		return lResult;
+
+	case WM_SETFOCUS:
+		if (w->onGetFocus) {
+			w->onGetFocus(w, w->onGetFocusData);
+			return 0;
+		}
+		break;
+	case WM_KILLFOCUS:
+		if (w->onLoseFocus) {
+			w->onLoseFocus(w, w->onLoseFocusData);
+			return 0;
+		}
+		break;
+
 	case WM_PRINTCLIENT:
 		// we do no special painting; just erase the background
 		// don't worry about the return value; we let DefWindowProcW() handle this message
@@ -386,6 +405,18 @@ void uiWindowOnClosing(uiWindow *w, int (*f)(uiWindow *, void *), void *data)
 	w->onClosingData = data;
 }
 
+void uiWindowOnGetFocus(uiWindow *w, void (*f)(uiWindow *, void *), void *data)
+{
+	w->onGetFocus = f;
+	w->onGetFocusData = data;
+}
+
+void uiWindowOnLoseFocus(uiWindow *w, void (*f)(uiWindow *, void *), void *data)
+{
+	w->onLoseFocus = f;
+	w->onLoseFocusData = data;
+}
+
 int uiWindowBorderless(uiWindow *w)
 {
 	return w->borderless;
@@ -510,6 +541,9 @@ uiWindow *uiNewWindow(const char *title, int width, int height, int hasMenubar)
 
 	uiWindowOnClosing(w, defaultOnClosing, NULL);
 	uiWindowOnContentSizeChanged(w, defaultOnPositionContentSizeChanged, NULL);
+
+	uiWindowOnGetFocus(w, NULL, NULL);
+	uiWindowOnLoseFocus(w, NULL, NULL);
 
 	windows[w] = true;
 	return w;


### PR DESCRIPTION
Tested on mac and linux. ~~Windows is still untested.~~
completes #52 
what do you think about the names GetFocus and LoseFocus? andlabs said [here](https://github.com/andlabs/libui/pull/378#issuecomment-411694239): 
> Not too happy with the names GetFocus/LoseFocus, as those names tend to refer to keyboard focus, not becoming the active window

should we change them? 
Edit: Tested it on Windows, does seem to work with no issues.