### PR TITLE
Center new windows on MacOS

### DIFF
--- a/darwin/window.m
+++ b/darwin/window.m
@@ -202,6 +202,7 @@ static void uiWindowShow(uiControl *c)
 
 	[w->window makeKeyAndOrderFront:w->window];
 	[w->window center];
+	[[NSApplication sharedApplication] activateIgnoringOtherApps:YES];
 }
 
 static void uiWindowHide(uiControl *c)


### PR DESCRIPTION
In lieu of a more comprehensive solution adding this one line causes new windows on macOS to appear in the center of the screen instead of in the lower left hand corner.