### PR TITLE
Ignore ERROR_SUCCESS in Windows InitCommonControlsEx()

### DIFF
--- a/windows/init.cpp
+++ b/windows/init.cpp
@@ -105,8 +105,12 @@ const char *uiInit(uiInitOptions *o)
 	ZeroMemory(&icc, sizeof (INITCOMMONCONTROLSEX));
 	icc.dwSize = sizeof (INITCOMMONCONTROLSEX);
 	icc.dwICC = wantedICCClasses;
-	if (InitCommonControlsEx(&icc) == 0)
-		return ieLastErr("initializing Common Controls");
+        if (InitCommonControlsEx(&icc) == 0) {
+            if (GetLastError() != ERROR_SUCCESS) {
+                return ieLastErr("initializing Common Controls");
+            }
+        }
+
 
 	hr = CoInitialize(NULL);
 	if (hr != S_OK && hr != S_FALSE)


### PR DESCRIPTION
As per typical Microsoft behavior, `InitCommonControlsEx` appears to sometimes fail with an error of ERROR_SUCCESS. The library totally works fine in this case. I have not investigated really deeply but it seems this fixes init in this case. Platform is Windows 10 x64.

It's being used from a Rust app so it's possible that this is happening because Rust's `winapi` crate is calling another initializer or something, but I don't know. Just know that the library works fine if you ignore an error of "SUCCESS."