### PR TITLE
Position caret at end after uiEntrySetText() on Windows, replicating …

### DIFF
--- a/windows/entry.cpp
+++ b/windows/entry.cpp
@@ -66,6 +66,10 @@ void uiEntrySetText(uiEntry *e, const char *text)
 	// doing this raises an EN_CHANGED
 	e->inhibitChanged = TRUE;
 	uiWindowsSetWindowText(e->hwnd, text);
+        int l = (int)strlen(text);
+        if (l >= 0) {
+            SendMessage(e->hwnd, EM_SETSEL, l, l);
+        }
 	e->inhibitChanged = FALSE;
 	// don't queue the control for resize; entry sizes are independent of their contents
 }

--- a/windows/entry.cpp
+++ b/windows/entry.cpp
@@ -63,13 +63,12 @@ char *uiEntryText(uiEntry *e)
 
 void uiEntrySetText(uiEntry *e, const char *text)
 {
+	int l;
 	// doing this raises an EN_CHANGED
 	e->inhibitChanged = TRUE;
 	uiWindowsSetWindowText(e->hwnd, text);
-        int l = (int)strlen(text);
-        if (l >= 0) {
-            SendMessage(e->hwnd, EM_SETSEL, l, l);
-        }
+        l = (int)strlen(text);
+        SendMessage(e->hwnd, EM_SETSEL, l, l);
 	e->inhibitChanged = FALSE;
 	// don't queue the control for resize; entry sizes are independent of their contents
 }

--- a/windows/entry.cpp
+++ b/windows/entry.cpp
@@ -64,10 +64,12 @@ char *uiEntryText(uiEntry *e)
 void uiEntrySetText(uiEntry *e, const char *text)
 {
 	int l;
+	if (!text)
+		text = "";
 	// doing this raises an EN_CHANGED
 	e->inhibitChanged = TRUE;
 	uiWindowsSetWindowText(e->hwnd, text);
-        l = (int)strlen(text);
+	l = (int)strlen(text);
         SendMessage(e->hwnd, EM_SETSEL, l, l);
 	e->inhibitChanged = FALSE;
 	// don't queue the control for resize; entry sizes are independent of their contents

--- a/windows/entry.cpp
+++ b/windows/entry.cpp
@@ -68,10 +68,10 @@ void uiEntrySetText(uiEntry *e, const char *text)
 		text = "";
 	// doing this raises an EN_CHANGED
 	e->inhibitChanged = TRUE;
-	uiWindowsSetWindowText(e->hwnd, text);
-	l = (int)strlen(text);
-        SendMessage(e->hwnd, EM_SETSEL, l, l);
-	e->inhibitChanged = FALSE;
+        uiWindowsSetWindowText(e->hwnd, text);
+        l = (int)strlen(text);
+        SendMessage(e->hwnd, EM_SETSEL, l, l);
+        e->inhibitChanged = FALSE;
 	// don't queue the control for resize; entry sizes are independent of their contents
 }
 

--- a/windows/entry.cpp
+++ b/windows/entry.cpp
@@ -64,8 +64,6 @@ char *uiEntryText(uiEntry *e)
 void uiEntrySetText(uiEntry *e, const char *text)
 {
 	int l;
-	if (!text)
-		text = "";
 	// doing this raises an EN_CHANGED
 	e->inhibitChanged = TRUE;
         uiWindowsSetWindowText(e->hwnd, text);


### PR DESCRIPTION
…behavior on MacOS

Just that. A few lines.