### PR TITLE
darwin: Fix keyboard handling for edit events.

### DIFF
--- a/darwin/event.m
+++ b/darwin/event.m
@@ -1,0 +1,36 @@
+#import "uipriv_darwin.h"
+
+/**
+ * Handle keyboard events related to editing (cut, copy, paste, select all, undo, redo).
+ *
+ * Special handling of these events is necessary as macOS does not handle these in the
+ * absence of an *Edit* menu.
+ *
+ * @returns `TRUE` if an event was processed, `FALSE` otherwise.
+ */
+BOOL uiprivSendKeyboardEditEvents(uiprivApplicationClass *app, NSEvent *e)
+{
+	NSString *action;
+	NSEventModifierFlags flags;
+	NSDictionary *keyAction = @{
+		@"x": @"cut:",
+		@"c": @"copy:",
+		@"v": @"paste:",
+		@"a": @"selectAll:",
+		@"z": @"undo:",
+		@"Z": @"redo:"
+	};
+
+	if ([e type] != NSKeyDown)
+		return FALSE;
+
+	flags = [e modifierFlags] & NSDeviceIndependentModifierFlagsMask;
+	if (flags != NSCommandKeyMask && flags != (NSCommandKeyMask | NSShiftKeyMask))
+		return FALSE;
+
+	action = keyAction[[e charactersIgnoringModifiers]];
+	if (action == nil)
+		return FALSE;
+
+	return [app sendAction:NSSelectorFromString(action) to:nil from:app];
+}

--- a/darwin/event.m
+++ b/darwin/event.m
@@ -10,16 +10,10 @@
  */
 BOOL uiprivSendKeyboardEditEvents(uiprivApplicationClass *app, NSEvent *e)
 {
-	NSString *action;
+	char key;
+	SEL action;
+	NSString *chars;
 	NSEventModifierFlags flags;
-	NSDictionary *keyAction = @{
-		@"x": @"cut:",
-		@"c": @"copy:",
-		@"v": @"paste:",
-		@"a": @"selectAll:",
-		@"z": @"undo:",
-		@"Z": @"redo:"
-	};
 
 	if ([e type] != NSKeyDown)
 		return FALSE;
@@ -28,9 +22,20 @@ BOOL uiprivSendKeyboardEditEvents(uiprivApplicationClass *app, NSEvent *e)
 	if (flags != NSCommandKeyMask && flags != (NSCommandKeyMask | NSShiftKeyMask))
 		return FALSE;
 
-	action = keyAction[[e charactersIgnoringModifiers]];
-	if (action == nil)
+	chars = [e charactersIgnoringModifiers];
+	if ([chars length] != 1)
 		return FALSE;
 
-	return [app sendAction:NSSelectorFromString(action) to:nil from:app];
+	key = [chars UTF8String][0];
+	switch (key) {
+		case 'x': action = @selector(cut:);       break;
+		case 'c': action = @selector(copy:);      break;
+		case 'v': action = @selector(paste:);     break;
+		case 'a': action = @selector(selectAll:); break;
+		case 'z': action = @selector(undo:);      break;
+		case 'Z': action = @selector(redo:);      break;
+		default: return FALSE;
+	}
+
+	return [app sendAction:action to:nil from:app];
 }

--- a/darwin/main.m
+++ b/darwin/main.m
@@ -16,6 +16,8 @@ static BOOL stepsIsRunning;
 {
 	if (uiprivSendAreaEvents(e) != 0)
 		return;
+	if (uiprivSendKeyboardEditEvents(self, e))
+		return;
 	[super sendEvent:e];
 }
 

--- a/darwin/meson.build
+++ b/darwin/meson.build
@@ -19,6 +19,7 @@ libui_sources += [
 	'darwin/drawtext.m',
 	'darwin/editablecombo.m',
 	'darwin/entry.m',
+	'darwin/event.m',
 	'darwin/fontbutton.m',
 	'darwin/fontmatch.m',
 	'darwin/fonttraits.m',

--- a/darwin/uipriv_darwin.h
+++ b/darwin/uipriv_darwin.h
@@ -161,3 +161,6 @@ extern BOOL uiprivFUTURE_NSWindow_performWindowDragWithEvent(NSWindow *w, NSEven
 extern CFStringRef uiprivUNDOC_kCTFontPreferredSubFamilyNameKey;
 extern CFStringRef uiprivUNDOC_kCTFontPreferredFamilyNameKey;
 extern void uiprivLoadUndocumented(void);
+
+// event.m
+extern BOOL uiprivSendKeyboardEditEvents(uiprivApplicationClass *app, NSEvent *e);


### PR DESCRIPTION
Fix handling of keyboard shortcuts in the absence of an Edit menu:
cut, copy, paste, select all, undo, redo.

This is the most simple work around I could come up with. It should work not only for uiEntry but the other controls too, hence it's own file.

Related to #103
Replaces #104

Edit: unix and windows work out of the box and do not need any special handling.