### PR TITLE
darwin: Fix some of the easy to fix compile time warnings

### DIFF
--- a/darwin/drawtext.m
+++ b/darwin/drawtext.m
@@ -230,3 +230,4 @@ void uiFreeFontDescriptor(uiFontDescriptor *desc)
 	// TODO ensure this is synchronized with fontmatch.m
 	uiFreeText((char *) (desc->Family));
 }
+

--- a/darwin/fontbutton.m
+++ b/darwin/fontbutton.m
@@ -132,7 +132,7 @@ struct uiFontButton {
 	(*(b->onChanged))(b, b->onChangedData);
 }
 
-- (NSUInteger)validModesForFontPanel:(NSFontPanel *)panel
+- (NSFontPanelModeMask)validModesForFontPanel:(NSFontPanel *)panel
 {
 	return NSFontPanelFaceModeMask |
 		NSFontPanelSizeModeMask |

--- a/darwin/grid.m
+++ b/darwin/grid.m
@@ -244,7 +244,7 @@ struct uiGrid {
 	NSView ***gv;
 	BOOL **gspan;
 	int x, y;
-	int i;
+	NSUInteger i;
 	NSLayoutConstraint *c;
 	int firstx, firsty;
 	BOOL *hexpand, *vexpand;

--- a/darwin/main.m
+++ b/darwin/main.m
@@ -199,7 +199,6 @@ int uiMainStep(int wait)
 // - https://github.com/gnustep/gui/blob/master/Source/NSApplication.m
 int uiprivMainStep(uiprivNextEventArgs *nea, BOOL (^interceptEvent)(NSEvent *e))
 {
-	NSDate *expire;
 	NSEvent *e;
 	NSEventType type;
 


### PR DESCRIPTION
Similar to #87 this PR removes some of the low hanging fruit to eventually arrive at no  compile time warnings, see #84.