### PR TITLE
windows: Add C-style include guards to header files.

### DIFF
--- a/windows/_uipriv_migrate.hpp
+++ b/windows/_uipriv_migrate.hpp
@@ -1,3 +1,5 @@
+#ifndef __LIBUI__UIPRIV_MIGRATE_HPP__
+#define __LIBUI__UIPRIV_MIGRATE_HPP__
 
 // menu.c
 extern HMENU makeMenubar(void);
@@ -12,3 +14,6 @@ extern void uninitDraw(void);
 extern ID2D1HwndRenderTarget *makeHWNDRenderTarget(HWND hwnd);
 extern uiDrawContext *newContext(ID2D1RenderTarget *);
 extern void freeContext(uiDrawContext *);
+
+#endif
+

--- a/windows/area.hpp
+++ b/windows/area.hpp
@@ -1,4 +1,5 @@
-// 18 december 2015
+#ifndef __LIBUI_AREA_HPP__
+#define __LIBUI_AREA_HPP__
 
 // TODOs
 // - things look very wrong on initial draw
@@ -43,3 +44,6 @@ extern BOOL areaDoEvents(uiArea *a, UINT uMsg, WPARAM wParam, LPARAM lParam, LRE
 extern void loadAreaSize(uiArea *a, ID2D1RenderTarget *rt, double *width, double *height);
 extern void pixelsToDIP(uiArea *a, double *x, double *y);
 extern void dipToPixels(uiArea *a, double *x, double *y);
+
+#endif
+

--- a/windows/attrstr.hpp
+++ b/windows/attrstr.hpp
@@ -1,4 +1,6 @@
-// 11 march 2018
+#ifndef __LIBUI_ATTRSTR_HPP__
+#define __LIBUI_ATTRSTR_HPP__
+
 #include "../common/attrstr.h"
 
 // dwrite.cpp
@@ -83,3 +85,6 @@ extern BOOL uiprivShowFontDialog(HWND parent, struct fontDialogParams *params);
 extern void uiprivLoadInitialFontDialogParams(struct fontDialogParams *params);
 extern void uiprivDestroyFontDialogParams(struct fontDialogParams *params);
 extern WCHAR *uiprivFontDialogParamsToString(struct fontDialogParams *params);
+
+#endif
+

--- a/windows/compilerver.hpp
+++ b/windows/compilerver.hpp
@@ -1,4 +1,5 @@
-// 9 june 2015
+#ifndef __LIBUI_COMPILERVER__
+#define __LIBUI_COMPILERVER__
 
 // Visual Studio (Microsoft's compilers)
 // VS2013 is needed for va_copy().
@@ -93,3 +94,6 @@ so I'm not sure what is correct, but I do need to find out
 #if WCHAR_MAX > 0xFFFF
 #error unexpected: wchar_t larger than 16-bit on a Windows ABI build; contact andlabs with your build setup information
 #endif
+
+#endif
+

--- a/windows/draw.hpp
+++ b/windows/draw.hpp
@@ -1,4 +1,5 @@
-// 5 may 2016
+#ifndef __LIBUI_DRAW_HPP__
+#define __LIBUI_DRAW_HPP__
 
 // TODO resolve overlap between this and the other hpp files (some functions leaked into uipriv_windows.hpp)
 
@@ -16,3 +17,6 @@ extern ID2D1PathGeometry *pathGeometry(uiDrawPath *p);
 
 // drawmatrix.cpp
 extern void m2d(uiDrawMatrix *m, D2D1_MATRIX_3X2_F *d);
+
+#endif
+

--- a/windows/resources.hpp
+++ b/windows/resources.hpp
@@ -1,4 +1,5 @@
-// 30 may 2015
+#ifndef __LIBUI_RESOURCES_HPP__
+#define __LIBUI_RESOURCES_HPP__
 
 #define rcTabPageDialog 29000
 #define rcFontDialog 29001
@@ -35,3 +36,6 @@
 #define rcBLabel 1121
 #define rcALabel 1122
 #define rcHexLabel 1123
+
+#endif
+

--- a/windows/table.hpp
+++ b/windows/table.hpp
@@ -1,4 +1,6 @@
-// 10 june 2018
+#ifndef __LIBUI_TABLE_HPP__
+#define __LIBUI_TABLE_HPP__
+
 #include "../common/table.h"
 
 // table.cpp
@@ -81,3 +83,6 @@ struct uiprivTableMetrics {
 	RECT realTextRect;
 };
 extern HRESULT uiprivTableGetMetrics(uiTable *t, int iItem, int iSubItem, uiprivTableMetrics **mout);
+
+#endif
+

--- a/windows/uipriv_windows.hpp
+++ b/windows/uipriv_windows.hpp
@@ -1,4 +1,6 @@
-// 21 april 2016
+#ifndef __LIBUI_UIPRIV_WINDOWS_HPP__
+#define __LIBUI_UIPRIV_WINDOWS_HPP__
+
 #include "winapi.hpp"
 #include "../ui.h"
 #include "../ui_windows.h"
@@ -172,3 +174,6 @@ extern HRESULT uiprivInitImage(void);
 extern void uiprivUninitImage(void);
 extern IWICBitmap *uiprivImageAppropriateForDC(uiImage *i, HDC dc);
 extern HRESULT uiprivWICToGDI(IWICBitmap *b, HDC dc, int width, int height, HBITMAP *hb);
+
+#endif
+

--- a/windows/winapi.hpp
+++ b/windows/winapi.hpp
@@ -1,4 +1,6 @@
-// 31 may 2015
+#ifndef __LIBUI_WINAPI_HPP__
+#define __LIBUI_WINAPI_HPP__
+
 #define UNICODE
 #define _UNICODE
 #define STRICT
@@ -62,3 +64,6 @@
 #include <functional>
 #include <utility>
 #endif
+
+#endif
+


### PR DESCRIPTION
Amazed that this has not become a problem before.

I am planning to rip out all the other nonsense in the headers later.