### PR TITLE
Fix meson builds with msvc to make them truly static.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -91,6 +91,20 @@ if libui_MSVC
 		'/MANIFEST:NO',
 	]
 
+	if libui_mode == 'shared'
+		if libui_is_debug
+			libui_project_compile_args += ['/MDd']
+		else
+			libui_project_compile_args += ['/MD']
+		endif
+	elif libui_mode == 'static'
+		if libui_is_debug
+			libui_project_compile_args += ['/MTd']
+		else
+			libui_project_compile_args += ['/MT']
+		endif
+	endif
+
 	# TODO autogenerate a .def file?
 else
 	libui_project_compile_args += [


### PR DESCRIPTION
Similar to mingw-w64 we need special flags to compile
the CRT in statically on static build with msvc.

Otherwise users need to install the redistributeable
package matching the compiler used for building,
making the build not full stand alone.

I hope this fixes #67. For me this patch definitely fixes the `vcruntime140.dll` error and I am able to run the resulting executables fully stand alone. I am unsure about `msvcp140.dll`  as I have never seen that one before. 

See:
https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-170