### PR TITLE
Fix mingw warnings.

### DIFF
--- a/windows/areascroll.cpp
+++ b/windows/areascroll.cpp
@@ -134,6 +134,7 @@ static void hscrollParams(uiArea *a, struct scrollParams *p)
 	p->wheelSPIAction = SPI_GETWHEELSCROLLCHARS;
 }
 
+/*
 static void hscrollto(uiArea *a, int pos)
 {
 	struct scrollParams p;
@@ -141,6 +142,7 @@ static void hscrollto(uiArea *a, int pos)
 	hscrollParams(a, &p);
 	scrollto(a, SB_HORZ, &p, pos);
 }
+*/
 
 static void hscrollby(uiArea *a, int delta)
 {
@@ -179,6 +181,7 @@ static void vscrollParams(uiArea *a, struct scrollParams *p)
 	p->wheelSPIAction = SPI_GETWHEELSCROLLLINES;
 }
 
+/*
 static void vscrollto(uiArea *a, int pos)
 {
 	struct scrollParams p;
@@ -186,6 +189,7 @@ static void vscrollto(uiArea *a, int pos)
 	vscrollParams(a, &p);
 	scrollto(a, SB_VERT, &p, pos);
 }
+*/
 
 static void vscrollby(uiArea *a, int delta)
 {

--- a/windows/attrstr.cpp
+++ b/windows/attrstr.cpp
@@ -335,7 +335,8 @@ static uiForEach processAttribute(const uiAttributedString *s, const uiAttribute
 		hr = p->layout->SetUnderline(hasUnderline, range);
 		if (hr != S_OK)
 			logHRESULT(L"error applying underline attribute", hr);
-		// and fall through to set the underline style through the drawing effect
+		// fall through to set the underline style through the drawing effect
+		// fall through
 	case uiAttributeTypeColor:
 	case uiAttributeTypeUnderlineColor:
 		// TODO const-correct this properly

--- a/windows/box.cpp
+++ b/windows/box.cpp
@@ -35,10 +35,8 @@ static void boxRelayout(uiBox *b)
 	int xpadding, ypadding;
 	int nStretchy;
 	int stretchywid, stretchyht;
-	int i;
 	int minimumWidth, minimumHeight;
 	int nVisible;
-	uiWindowsSizing *d;
 
 	if (b->controls->size() == 0)
 		return;
@@ -164,10 +162,8 @@ static void uiBoxMinimumSize(uiWindowsControl *c, int *width, int *height)
 	// these two contain the largest minimum width and height of all stretchy controls in the box
 	// all stretchy controls will use this value to determine the final minimum size
 	int maxStretchyWidth, maxStretchyHeight;
-	int i;
 	int minimumWidth, minimumHeight;
 	int nVisible;
-	uiWindowsSizing sizing;
 
 	*width = 0;
 	*height = 0;

--- a/windows/colordialog.cpp
+++ b/windows/colordialog.cpp
@@ -87,7 +87,6 @@ static void hsv2RGB(double h, double s, double v, double *r, double *g, double *
 	int h60;
 	double x;
 	double m;
-	double c1, c2;
 
 	c = v * s;
 	hPrime = h * 6;

--- a/windows/compilerver.hpp
+++ b/windows/compilerver.hpp
@@ -9,9 +9,11 @@
 #endif
 #endif
 
-// LONGTERM MinGW
-
-// other compilers can be added here as necessary
+#ifdef __MINGW32__
+// Silence warning: base class 'struct IUnknown' has accessible non-virtual destructor
+// as MinGW does not process COM interfaces correctly
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+#endif
 
 /* TODO this should not be necessary, but I don't know
 

--- a/windows/drawtext.cpp
+++ b/windows/drawtext.cpp
@@ -475,7 +475,6 @@ public:
 // TODO this ignores clipping?
 void uiDrawText(uiDrawContext *c, uiDrawTextLayout *tl, double x, double y)
 {
-	D2D1_POINT_2F pt;
 	ID2D1SolidColorBrush *black;
 	textRenderer *renderer;
 	HRESULT hr;

--- a/windows/drawtext.cpp
+++ b/windows/drawtext.cpp
@@ -479,9 +479,11 @@ void uiDrawText(uiDrawContext *c, uiDrawTextLayout *tl, double x, double y)
 	textRenderer *renderer;
 	HRESULT hr;
 
+	/*
 	for (auto p : *(tl->backgroundParams)) {
 		// TODO
 	}
+	*/
 
 	// TODO document that fully opaque black is the default text color; figure out whether this is upheld in various scenarios on other platforms
 	// TODO figure out if this needs to be cleaned out

--- a/windows/entry.cpp
+++ b/windows/entry.cpp
@@ -126,9 +126,11 @@ uiEntry *uiNewSearchEntry(void)
 	HRESULT hr;
 
 	e = finishNewEntry(0);
-	// TODO this is from ThemeExplorer; is it documented anywhere?
-	// TODO SearchBoxEditComposited has no border
-	hr = SetWindowTheme(e->hwnd, L"SearchBoxEdit", NULL);
-	// TODO will hr be S_OK if themes are disabled?
+
+	hr = SetWindowTheme(e->hwnd, L"SearchBoxEditComposited", NULL);
+	if (hr != S_OK || !IsAppThemed()) {
+		//TODO log: Failed to apply search box theme.
+	}
+
 	return e;
 }

--- a/windows/events.cpp
+++ b/windows/events.cpp
@@ -144,8 +144,6 @@ void uiWindowsUnregisterReceiveWM_WININICHANGE(HWND hwnd)
 
 void issueWM_WININICHANGE(WPARAM wParam, LPARAM lParam)
 {
-	struct wininichange *ch;
-
 	for (const auto &iter : wininichanges)
 		SendMessageW(iter.first, WM_WININICHANGE, wParam, lParam);
 }

--- a/windows/form.cpp
+++ b/windows/form.cpp
@@ -39,7 +39,6 @@ static void formRelayout(uiForm *f)
 	int nStretchy;
 	int labelwid, stretchyht;
 	int thiswid;
-	int i;
 	int minimumWidth, minimumHeight;
 	uiWindowsSizing sizing;
 	int labelht, labelyoff;
@@ -170,10 +169,8 @@ static void uiFormMinimumSize(uiWindowsControl *c, int *width, int *height)
 	int maxLabelWidth, maxControlWidth;
 	int maxStretchyHeight;
 	int labelwid;
-	int i;
 	int minimumWidth, minimumHeight;
 	int nVisible;
-	uiWindowsSizing sizing;
 
 	*width = 0;
 	*height = 0;
@@ -244,7 +241,6 @@ static void formArrangeChildren(uiForm *f)
 {
 	LONG_PTR controlID;
 	HWND insertAfter;
-	int i;
 
 	controlID = 100;
 	insertAfter = NULL;

--- a/windows/grid.cpp
+++ b/windows/grid.cpp
@@ -134,7 +134,7 @@ public:
 
 	~gridLayoutData()
 	{
-		size_t y;
+		int y;
 
 		delete[] this->hexpand;
 		delete[] this->vexpand;

--- a/windows/grid.cpp
+++ b/windows/grid.cpp
@@ -189,7 +189,7 @@ static void gridPadding(uiGrid *g, int *xpadding, int *ypadding)
 static void gridRelayout(uiGrid *g)
 {
 	RECT r;
-	int x, y, width, height;
+	int width, height;
 	gridLayoutData *ld;
 	int xpadding, ypadding;
 	int ix, iy;
@@ -202,8 +202,6 @@ static void gridRelayout(uiGrid *g)
 		return;		// nothing to do
 
 	uiWindowsEnsureGetClientRect(g->hwnd, &r);
-	x = r.left;
-	y = r.top;
 	width = r.right - r.left;
 	height = r.bottom - r.top;
 

--- a/windows/tabledispinfo.cpp
+++ b/windows/tabledispinfo.cpp
@@ -11,7 +11,6 @@ static HRESULT handleLVIF_TEXT(uiTable *t, NMLVDISPINFOW *nm, uiprivTableColumnP
 	uiTableValue *value;
 	WCHAR *wstr;
 	int progress;
-	HRESULT hr;
 
 	if ((nm->item.mask & LVIF_TEXT) == 0)
 		return S_OK;
@@ -59,9 +58,6 @@ static HRESULT handleLVIF_TEXT(uiTable *t, NMLVDISPINFOW *nm, uiprivTableColumnP
 
 static HRESULT handleLVIF_IMAGE(uiTable *t, NMLVDISPINFOW *nm, uiprivTableColumnParams *p)
 {
-	uiTableValue *value;
-	HRESULT hr;
-
 	if (nm->item.iSubItem == 0 && p->imageModelColumn == -1 && p->checkboxModelColumn == -1) {
 		// Having an image list always leaves space for an image
 		// on the main item :|

--- a/windows/tabledraw.cpp
+++ b/windows/tabledraw.cpp
@@ -221,7 +221,6 @@ static HRESULT drawTextPart(HRESULT hr, struct drawState *s)
 {
 	COLORREF prevText;
 	int prevMode;
-	RECT r;
 	uiTableValue *value;
 	WCHAR *wstr;
 
@@ -482,7 +481,7 @@ fail:
 
 static HRESULT freeDrawState(struct drawState *s)
 {
-	HRESULT hr, hrret;
+	HRESULT hrret;
 
 	hrret = S_OK;
 	if (s->m != NULL) {
@@ -526,8 +525,6 @@ static COLORREF blend(COLORREF base, double r, double g, double b, double a)
 
 static HRESULT fillDrawState(struct drawState *s, uiTable *t, NMLVCUSTOMDRAW *nm, uiprivTableColumnParams *p)
 {
-	LRESULT state;
-	HWND header;
 	HRESULT hr;
 
 	ZeroMemory(s, sizeof (struct drawState));

--- a/windows/tabledraw.cpp
+++ b/windows/tabledraw.cpp
@@ -595,7 +595,7 @@ static HRESULT updateAndDrawFocusRects(HRESULT hr, uiTable *t, HDC dc, int iItem
 	if ((state & LVIS_FOCUSED) == 0)
 		return S_OK;
 
-	if (realTextBackground != NULL)
+	if (realTextBackground != NULL) {
 		if (*first) {
 			*focus = *realTextBackground;
 			*first = false;
@@ -604,6 +604,7 @@ static HRESULT updateAndDrawFocusRects(HRESULT hr, uiTable *t, HDC dc, int iItem
 			focus->right = realTextBackground->right;
 			return S_OK;
 		}
+	}
 	if (DrawFocusRect(dc, focus) == 0) {
 		logLastError(L"DrawFocusRect()");
 		return E_FAIL;

--- a/windows/tableediting.cpp
+++ b/windows/tableediting.cpp
@@ -195,7 +195,7 @@ HRESULT uiprivTableHandleNM_CLICK(uiTable *t, NMITEMACTIVATE *nm, LRESULT *lResu
 	int modelColumn, editableColumn;
 	bool text, checkbox;
 	uiTableValue *value;
-	int checked, editable;
+	int checked;
 	HRESULT hr;
 
 	ZeroMemory(&ht, sizeof (LVHITTESTINFO));


### PR DESCRIPTION
Fix some of the mingw compile warnings. These are the straight forward ones.
There is still more to come, but I would like to look into those a little more.

The grid stuff can probably be just casted away, but I wonder why int and size_t is so mixed in the first place.

Related to #84