### PR TITLE
Export libui_dep for use of libui-ng as a meson subproject.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -180,6 +180,10 @@ if libui_mode == 'static'
 	libui_binary_deps = libui_deps
 endif
 
+# Export symbols for use of libui as a meson subproject
+libui_dep = declare_dependency(include_directories: include_directories('.'),
+	link_with : libui_libui)
+
 if get_option('tests')
 	subdir('test')
 endif


### PR DESCRIPTION
Currently the meson.build does not export a variable so that the library can be used as a subproject.

The [meson docs](https://mesonbuild.com/Subprojects.html) suggest exporting a variable name `library_dep`. I went with `libui_dep` here as all the meson variables are called `libui_*`.

You can see an example project [here](https://github.com/szanni/sample-libui-ng). I'll update the URL to point the the main repo once this gets merged.

**Note:**

There are some other outstanding issues, namely that the parent project seemingly needs to define it's default options as `default_options: ['b_pch=false',  'c_std=c99', 'cpp_std=c++11']` (meson 0.62.2).

According to the [docs](https://mesonbuild.com/Subprojects.html) we should be able to pass `default_options` only to the subproject, but this does not work on my system for the options mentioned above. There are various closed bug reports like [this one](https://github.com/mesonbuild/meson/issues/2289).

With the newest meson (0.63.0) I can actually drop the C and C++ std options, but still need `b_pch`. I guesss that is an upstream bug. Is there a reason libui forces C headers to not be precompiled? Seems like a strange restriction? Is this just old cruft?