### PR TITLE
Add initial accessibility automation APIs

### DIFF
--- a/test/main.c
+++ b/test/main.c
@@ -52,6 +52,7 @@ int main(int argc, char *argv[])
 	uiBox *page15;
 	uiBox *page16;
 	uiBox *page17;
+	uiBox *page18;
 	uiTab *outerTab;
 	uiTab *innerTab;
 	int nomenus = 0;
@@ -165,6 +166,9 @@ int main(int argc, char *argv[])
 
 	page17 = makePage17();
 	uiTabAppend(innerTab, "Page 17", uiControl(page17));
+
+	page18 = makePage18(w);
+	uiTabAppend(innerTab, "Page 18", uiControl(page18));
 
 	if (startspaced)
 		setSpaced(1);

--- a/test/meson.build
+++ b/test/meson.build
@@ -25,6 +25,7 @@ libui_test_sources = [
 	'page15.c',
 	'page16.c',
 	'page17.c',
+	'page18.c',
 	'spaced.c',
 ]
 

--- a/test/page18.c
+++ b/test/page18.c
@@ -1,0 +1,42 @@
+#include "test.h"
+
+static uiWindow *parent;
+static int clickedTimes;
+
+static void onButtonClicked(uiButton *b, void *data)
+{
+	char str[256];
+
+	clickedTimes++;
+	sprintf(str, "Clicked %d time%s", clickedTimes, clickedTimes > 1? "s" : "");
+	uiButtonSetText(b, str);
+}
+
+static void doButtonClick(uiButton *b, void *data)
+{
+	if (!uiA11yDoButtonClick(uiButton(data)))
+		uiMsgBoxError(parent, "Error: a11y", "Failed to automate button click.");
+}
+
+uiBox *makePage18(uiWindow *pw)
+{
+	uiBox *page18;
+	uiBox *controls;
+	uiButton *doButton, *button;
+
+	parent = pw;
+	page18 = newVerticalBox();
+	controls = newHorizontalBox();
+	uiBoxAppend(page18, uiControl(controls), 0);
+
+	button = uiNewButton("Click Me!");
+	doButton = uiNewButton("Do Click");
+	uiButtonOnClicked(doButton, doButtonClick, button);
+	uiBoxAppend(controls, uiControl(doButton), 0);
+	clickedTimes = 0;
+	uiButtonOnClicked(button, onButtonClicked, NULL);
+	uiBoxAppend(controls, uiControl(button), 0);
+
+	return page18;
+}
+

--- a/test/test.h
+++ b/test/test.h
@@ -98,5 +98,8 @@ extern void freePage16(void);
 extern uiBox *makePage17(void);
 extern void freePage17(void);
 
+// page18.c
+extern uiBox *makePage18(uiWindow *);
+
 // images.c
 extern void appendImageNamed(uiImage *img, const char *name);

--- a/ui.h
+++ b/ui.h
@@ -15,6 +15,7 @@
  * @defgroup dialogWindow Dialog windows
  * @defgroup menu Menus
  * @defgroup table Tables
+ * @defgroup a11y Accessibility
  */
 
 #ifndef __LIBUI_UI_H__
@@ -3798,6 +3799,23 @@ _UI_EXTERN int uiTableColumnWidth(uiTable *t, int column);
  * @memberof uiTable
  */
 _UI_EXTERN void uiTableColumnSetWidth(uiTable *t, int column, int width);
+
+/**
+ * Common methods for using accessibility automation.
+ *
+ * @struct uiA11y
+ * @ingroup a11y
+ */
+
+/**
+ * Automates the clicking of a button.
+ *
+ * @param b uiButton The button to click.
+ * @returns `TRUE` if successful, `FALSE` otherwise.
+ * @see uiButton
+ * @memberof uiA11y @static
+ */
+_UI_EXTERN int uiA11yDoButtonClick(uiButton *b);
 
 #ifdef __cplusplus
 }

--- a/unix/a11y.c
+++ b/unix/a11y.c
@@ -1,0 +1,26 @@
+#include "uipriv_unix.h"
+
+static int uiUnixA11yDoControlAction(uiControl *c, const char *name)
+{
+	GtkWidget *widget;
+	AtkObject *a11y;
+	AtkAction *action;
+	int i;
+
+	widget = GTK_WIDGET(uiControlHandle(c));
+	a11y = gtk_widget_get_accessible(widget);
+	action = ATK_ACTION(a11y);
+	for (i = 0; i < atk_action_get_n_actions(action); i++) {
+		if (strcmp(atk_action_get_name(action, i), name) == 0) {
+			if (atk_action_do_action(action, i))
+				return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+int uiA11yDoButtonClick(uiButton *b)
+{
+	return uiUnixA11yDoControlAction(uiControl(b), "click");
+}
+

--- a/unix/meson.build
+++ b/unix/meson.build
@@ -1,6 +1,7 @@
 # 23 march 2019
 
 libui_sources += [
+	'unix/a11y.c',
 	'unix/alloc.c',
 	'unix/area.c',
 	'unix/attrstr.c',


### PR DESCRIPTION
Basic implementation for uiButton on unix and darwin, missing windows.

Includes new Page 18 in tester for a11y.

`uiA11y` is also added here as a "shadow" class: the type does not actually exist from the perspective of native C code, it is merely for organizational purposes in language bindings and documentation.