### PR TITLE
test: Add manual testing suite for quality assurance.

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -49,3 +49,4 @@ executable('tester', libui_test_sources,
 	install: false)
 
 subdir('unit')
+subdir('qa')

--- a/test/qa/button.c
+++ b/test/qa/button.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+
+#include "qa.h"
+
+static void buttonOnClickedCb(uiButton *b, void *data)
+{
+	char str[32];
+	static int count = 0;
+	uiLabel *label = data;
+
+	sprintf(str, "%d", ++count);
+	uiLabelSetText(label, str);
+}
+
+const char *buttonOnClickedGuide() {
+	return
+	"1.\tYou should see a button with the text `Button`.\n"
+	"\tNext to it should a  label displaying `Click count: 0`.\n"
+	"\n"
+	"2.\tClick the button. The label should now read `Click count: 1`.\n"
+	"\n"
+	"3.\tClick the button again. The label should now read `Click count: 2`\n"
+	;
+}
+
+uiControl* buttonOnClicked()
+{
+	uiBox *hbox;
+	uiButton *button;
+	uiLabel *label;
+
+	hbox = uiNewHorizontalBox();
+	uiBoxSetPadded(hbox, 1);
+
+	button = uiNewButton("Button");
+	uiBoxAppend(hbox, uiControl(button), 0);
+
+	label = uiNewLabel("Click count:");
+	uiBoxAppend(hbox, uiControl(label), 0);
+
+	label = uiNewLabel("0");
+	uiBoxAppend(hbox, uiControl(label), 0);
+
+	uiButtonOnClicked(button, buttonOnClickedCb, label);
+
+	return uiControl(hbox);
+}

--- a/test/qa/checkbox.c
+++ b/test/qa/checkbox.c
@@ -1,0 +1,57 @@
+#include <stdio.h>
+
+#include "qa.h"
+
+static void checkboxOnToggledCb(uiCheckbox *c, void *data)
+{
+	char str[32];
+	uiLabel *label = data;
+	static int count = 0;
+
+	sprintf(str, "%d", ++count);
+	uiLabelSetText(label, str);
+}
+
+const char *checkboxOnToggledGuide() {
+	return
+	"1.\tYou should see an unchecked checkbox with the text `Checkbox`.\n"
+	"\tNext to it should a  label displaying `Toggle count: 0`.\n"
+	"\n"
+	"2.\tClick the square next to `Checkbox`. The checkbox should visually\n"
+	"\tchange to a checked state and the label should read `Toggle count: 1`.\n"
+	"\n"
+	"3.\tClick the square next to `Checkbox` again. The checkbox should\n"
+	"\tvisually revert back to an unchecked state and the label should read\n"
+	"\t `Toggle count: 2`.\n"
+	"\n"
+	"4.\tClick on the label `Checkbox`. The checkbox should visually\n"
+	"\tchange to a checked state and the label should read `Toggle count: 3`.\n"
+	"\n"
+	"5.\tClick the label `Checkbox` again. The checkbox should visually\n"
+	"\trevert back to an unchecked state and the label should read\n"
+	"\t `Toggle count: 4`.\n"
+	;
+}
+
+uiControl* checkboxOnToggled()
+{
+	uiBox *hbox;
+	uiCheckbox *checkbox;
+	uiLabel *label;
+
+	hbox = uiNewHorizontalBox();
+	uiBoxSetPadded(hbox, 1);
+
+	checkbox = uiNewCheckbox("Checkbox");
+	uiBoxAppend(hbox, uiControl(checkbox), 0);
+
+	label = uiNewLabel("Toggle count:");
+	uiBoxAppend(hbox, uiControl(label), 0);
+
+	label = uiNewLabel("0");
+	uiBoxAppend(hbox, uiControl(label), 0);
+
+	uiCheckboxOnToggled(checkbox, checkboxOnToggledCb, label);
+
+	return uiControl(hbox);
+}

--- a/test/qa/entry.c
+++ b/test/qa/entry.c
@@ -1,0 +1,156 @@
+#include <stdio.h>
+
+#include "qa.h"
+
+static void entryOnChangedCb(uiEntry *e, void *data)
+{
+	char str[32];
+	uiLabel *label = data;
+	static int count = 0;
+
+	sprintf(str, "%d", ++count);
+	uiLabelSetText(label, str);
+}
+
+const char *entryOnChangedGuide() {
+	return
+	"1.\tYou should see an empty text entry box. Next to it should be a label\n"
+	"\tdisplaying `Changed count: 0`.\n"
+	"\n"
+	"2.\tFocus the entry box by left clicking it. Type `1`, `2`, `3`. The\n"
+	"\tcontents of the entry box should read `123`. The label should read\n"
+	"\t`Changed count: 3`.\n"
+	"\n"
+	"3.\tPress the back space key. The contents of the entry box should read\n"
+	"\t`12`. The label should read `Changed count: 4`.\n"
+	;
+}
+
+uiControl* entryOnChanged()
+{
+	uiBox *vbox;
+	uiBox *hbox;
+	uiEntry *entry;
+	uiLabel *label;
+
+	vbox = uiNewVerticalBox();
+	uiBoxSetPadded(vbox, 1);
+
+	hbox = uiNewHorizontalBox();
+	uiBoxSetPadded(hbox, 1);
+	uiBoxAppend(vbox, uiControl(hbox), 0);
+
+	entry = uiNewEntry();
+	uiBoxAppend(hbox, uiControl(entry), 0);
+	label = uiNewLabel("Changed count:");
+	uiBoxAppend(hbox, uiControl(label), 0);
+	label = uiNewLabel("0");
+	uiBoxAppend(hbox, uiControl(label), 0);
+
+	uiEntryOnChanged(entry, entryOnChangedCb, label);
+
+	return uiControl(vbox);
+}
+
+static void passwordEntryOnChangedCb(uiEntry *e, void *data)
+{
+	char str[32];
+	uiLabel *label = data;
+	static int count = 0;
+
+	sprintf(str, "%d", ++count);
+	uiLabelSetText(label, str);
+}
+
+const char *passwordEntryOnChangedGuide() {
+	return
+	"1.\tYou should see an empty password entry box. Next to it should be a\n"
+	"\tlabel displaying `Changed count: 0`.\n"
+	"\n"
+	"2.\tFocus the password box by left clicking it. Type `1`, `2`, `3`. The\n"
+	"\tcontents of the password box should be obfuscated, `***`. The label\n"
+	"\tshould read `Changed count: 3`.\n"
+	"\n"
+	"3.\tPress the back space key. The contents of the password box should\n"
+	"\tremain obfuscated, `**`. The label should read `Changed count: 4`.\n"
+	;
+}
+
+uiControl* passwordEntryOnChanged()
+{
+	uiBox *vbox;
+	uiBox *hbox;
+	uiEntry *entry;
+	uiLabel *label;
+
+	vbox = uiNewVerticalBox();
+	uiBoxSetPadded(vbox, 1);
+
+	hbox = uiNewHorizontalBox();
+	uiBoxSetPadded(hbox, 1);
+	uiBoxAppend(vbox, uiControl(hbox), 0);
+
+	entry = uiNewPasswordEntry();
+	uiBoxAppend(hbox, uiControl(entry), 0);
+	label = uiNewLabel("Changed count:");
+	uiBoxAppend(hbox, uiControl(label), 0);
+	label = uiNewLabel("0");
+	uiBoxAppend(hbox, uiControl(label), 0);
+
+	uiEntryOnChanged(entry, passwordEntryOnChangedCb, label);
+
+	return uiControl(vbox);
+}
+
+static void searchEntryOnChangedCb(uiEntry *e, void *data)
+{
+	char str[32];
+	uiLabel *label = data;
+	static int count = 0;
+
+	sprintf(str, "%d", ++count);
+	uiLabelSetText(label, str);
+}
+
+const char *searchEntryOnChangedGuide() {
+	return
+	"1.\tYou should see an empty search box. Next to it should be a label\n"
+	"\tdisplaying `Changed count: 0`.\n"
+	"\n"
+	"2.\tFocus the search box by left clicking it. Type `1`, `2`, `3` as fast\n"
+	"\tas possible. The contents search box should read `123`. The label\n"
+	"\tshould read a maximum `Changed count` of `3`. Depending on how\n"
+	"\tfast you typed it ideally reads `1` or `2`.\n"
+	"\n"
+	"3.\tPress the back space key. The contents of the search box should read\n"
+	"\t`12`. The label `Changed count` should have increased by one\n"
+	"\tcompared to the prior step.\n"
+	;
+}
+
+uiControl* searchEntryOnChanged()
+{
+	uiBox *vbox;
+	uiBox *hbox;
+	uiEntry *entry;
+	uiLabel *label;
+
+	vbox = uiNewVerticalBox();
+	uiBoxSetPadded(vbox, 1);
+
+	hbox = uiNewHorizontalBox();
+	uiBoxSetPadded(hbox, 1);
+	uiBoxAppend(vbox, uiControl(hbox), 0);
+
+	entry = uiNewSearchEntry();
+	uiBoxAppend(hbox, uiControl(entry), 0);
+	label = uiNewLabel("Changed count:");
+	uiBoxAppend(hbox, uiControl(label), 0);
+	label = uiNewLabel("0");
+	uiBoxAppend(hbox, uiControl(label), 0);
+
+	uiEntryOnChanged(entry, searchEntryOnChangedCb, label);
+
+	return uiControl(vbox);
+}
+

--- a/test/qa/label.c
+++ b/test/qa/label.c
@@ -1,0 +1,49 @@
+#include "qa.h"
+
+const char *labelMultiLineGuide() {
+	return
+	"1.\tThe first line should read `Single line test`.\n"
+	"\n"
+	"2.\tNext are four invisible horizontal boxes.\n"
+	"\tThe first three should each have the width of the line `Long line`.\n"
+	"\tThe fourth box should take up the remaining space and consist of three\n"
+	"\tlines reading `Padding`.\n"
+	"\n"
+	"3.\tThe next line should read `Multi line height test` and should have a\n"
+	"\tsimilar distance to the four boxes as the first line `Single line test`."
+	;
+}
+
+uiControl* labelMultiLine()
+{
+	uiBox *vbox;
+	uiBox *hbox;
+	uiLabel *label;
+
+	vbox = uiNewVerticalBox();
+	uiBoxSetPadded(vbox, 1);
+
+	label = uiNewLabel("Single line test");
+	uiBoxAppend(vbox, uiControl(label), 0);
+
+	hbox = uiNewHorizontalBox();
+	uiBoxSetPadded(hbox, 1);
+	uiBoxAppend(vbox, uiControl(hbox), 0);
+
+	label = uiNewLabel("Long line\nShort\nShort");
+	uiBoxAppend(hbox, uiControl(label), 0);
+
+	label = uiNewLabel("Short\nLong line\nShort");
+	uiBoxAppend(hbox, uiControl(label), 0);
+
+	label = uiNewLabel("Short\nShort\nLong line");
+	uiBoxAppend(hbox, uiControl(label), 0);
+
+	label = uiNewLabel("Padding\nPadding\nPadding");
+	uiBoxAppend(hbox, uiControl(label), 1);
+
+	label = uiNewLabel("Multi line height test");
+	uiBoxAppend(vbox, uiControl(label), 0);
+
+	return uiControl(vbox);
+}

--- a/test/qa/main.c
+++ b/test/qa/main.c
@@ -1,0 +1,175 @@
+#include <stdio.h>
+
+#include "qa.h"
+
+struct controlTestCase {
+	const char *name;
+	uiControl* (*init)(void);
+	const char * (*guide)(void);
+};
+
+struct controlTestGroup {
+	const char *name;
+	struct controlTestCase *testCases;
+};
+
+#define QA_TEST(desciption, name) { desciption, name, name##Guide }
+
+struct controlTestCase labelTestCases[] = {
+	QA_TEST("1. Multi Line", labelMultiLine),
+	{NULL, NULL, NULL}
+};
+
+struct controlTestGroup controlTestGroups[] = {
+	{"uiLabel", labelTestCases},
+};
+
+uiControl* qaGuide()
+{
+	uiBox *box;
+	uiMultilineEntry *guide;
+
+	box = uiNewVerticalBox();
+
+	guide = uiNewMultilineEntry();
+	uiMultilineEntrySetText(guide,
+		"Welcome to quality assurance!\n"
+		"\n"
+		"Presented here are various manual test to ensure uiControls behave as expected.\n"
+		"\n"
+		"Usage:\n"
+		"1.\tSelect the desired uiControl to test from the drop down menu.\n"
+		"2.\tSelect a test case from the second drop down menu.\n"
+		"3.\tFollow the step by step instructions in the right hand pane.\n"
+		"4.\tIf the behavior or visual output does not match the description please report this upstream.\n"
+		"\n"
+		"Reporting a bug:\n"
+		"\tPlease check if a bug report describing the issue you found already exists.\n"
+		"\tIf that is the case, please leave a comment confirming the issue.\n"
+		"\tIf you can not find an existing report, please file a new one.\n"
+		"\n"
+		"\tPlease include:\n"
+		"\t- Library version or git commit hash\n"
+		"\t- Operating system(s)\n"
+		"\t- uiControl\n"
+		"\t- Test case\n"
+		"\t- Step number that failed\n"
+		"\n"
+		"\te.g.:\n"
+		"\tQA: 803389e3 > Windows 7 > uiLabel > 1. Multi Line > Step 6\n"
+		"\n"
+		"\tSubmit the report at https://github.com/libui-ng/libui-ng/issues"
+	);
+	uiBoxAppend(box, uiControl(guide), 1);
+	uiMultilineEntrySetReadOnly(guide, 1);
+
+	return uiControl(box);
+}
+
+uiBox *mainBox = NULL;
+static uiControl *qaBox = NULL;
+int testGroupIndex = -1;
+uiBox *chooserBox;
+uiCombobox *testCaseChooser = NULL;
+
+int onClosing(uiWindow *w, void *data)
+{
+	uiQuit();
+	return 1;
+}
+
+void clearCurrentBox()
+{
+	if (qaBox != NULL) {
+		uiBoxDelete(mainBox, 2);
+		uiControlDestroy(qaBox);
+		qaBox = NULL;
+	}
+}
+
+void testCaseOnSelected(uiCombobox *sender, void *senderData)
+{
+	clearCurrentBox();
+
+	struct controlTestCase testCase = controlTestGroups[testGroupIndex].testCases[uiComboboxSelected(sender)];
+	qaBox = qaMakeGuide(testCase.init(), testCase.guide());
+	uiBoxAppend(mainBox, qaBox, 1);
+}
+
+void testGroupOnSelected(uiCombobox *sender, void *senderData)
+{
+	clearCurrentBox();
+
+	testGroupIndex = uiComboboxSelected(sender) - 1;
+	if (testGroupIndex == -1) {
+		qaBox = qaGuide();
+		uiBoxAppend(mainBox, qaBox, 1);
+		uiControlHide(uiControl(testCaseChooser));
+	}
+	else {
+		int i = 0;
+		struct controlTestCase testCase;
+
+		uiComboboxClear(testCaseChooser);
+		while (testCase = controlTestGroups[testGroupIndex].testCases[i], testCase.name != NULL) {
+			uiComboboxAppend(testCaseChooser, testCase.name);
+			i++;
+		}
+		uiControlShow(uiControl(testCaseChooser));
+		if (uiComboboxNumItems(testCaseChooser) > 0) {
+			uiComboboxSetSelected(testCaseChooser, 0);
+			testCaseOnSelected(testCaseChooser, NULL);
+		}
+	}
+}
+
+
+int main(int argc, char *argv[])
+{
+	size_t i;
+	uiInitOptions o = {0};
+	const char *err;
+	uiWindow *w;
+	uiCombobox *testGroupChooser;
+
+	err = uiInit(&o);
+	if (err != NULL) {
+		fprintf(stderr, "error initializing ui: %s\n", err);
+		uiFreeInitError(err);
+		return 1;
+	}
+
+	w = uiNewWindow("Quality Assurance", 960, 720, 1);
+	uiWindowSetMargined(w, 1);
+	uiWindowOnClosing(w, onClosing, NULL);
+
+	mainBox = uiNewVerticalBox();
+	uiBoxSetPadded(mainBox, 1);
+	uiWindowSetChild(w, uiControl(mainBox));
+
+	chooserBox = uiNewHorizontalBox();
+	uiBoxSetPadded(chooserBox, 1);
+	uiBoxAppend(mainBox, uiControl(chooserBox), 0);
+	uiBoxAppend(mainBox, uiControl(uiNewHorizontalSeparator()), 0);
+
+	testGroupChooser = uiNewCombobox();
+	uiBoxAppend(chooserBox, uiControl(testGroupChooser), 0);
+
+	testCaseChooser = uiNewCombobox();
+	uiBoxAppend(chooserBox, uiControl(testCaseChooser), 0);
+	uiComboboxOnSelected(testCaseChooser, testCaseOnSelected, NULL);
+
+	uiComboboxAppend(testGroupChooser, "QA Guide");
+	for (i = 0; i < sizeof(controlTestGroups)/sizeof(*controlTestGroups); ++i)
+		uiComboboxAppend(testGroupChooser, controlTestGroups[i].name);
+
+	uiComboboxSetSelected(testGroupChooser, 0);
+	uiComboboxOnSelected(testGroupChooser, testGroupOnSelected, NULL);
+	testGroupOnSelected(testGroupChooser, mainBox);
+
+	uiControlShow(uiControl(w));
+	uiMain();
+	uiUninit();
+
+	return 0;
+}

--- a/test/qa/main.c
+++ b/test/qa/main.c
@@ -20,6 +20,11 @@ struct controlTestCase buttonTestCases[] = {
 	{NULL, NULL, NULL}
 };
 
+struct controlTestCase checkboxTestCases[] = {
+	QA_TEST("1. Checkbox OnToggled Callback", checkboxOnToggled),
+	{NULL, NULL, NULL}
+};
+
 struct controlTestCase labelTestCases[] = {
 	QA_TEST("1. Multi Line", labelMultiLine),
 	{NULL, NULL, NULL}
@@ -27,6 +32,7 @@ struct controlTestCase labelTestCases[] = {
 
 struct controlTestGroup controlTestGroups[] = {
 	{"uiButton", buttonTestCases},
+	{"uiCheckbox", checkboxTestCases},
 	{"uiLabel", labelTestCases},
 };
 

--- a/test/qa/main.c
+++ b/test/qa/main.c
@@ -25,6 +25,13 @@ struct controlTestCase checkboxTestCases[] = {
 	{NULL, NULL, NULL}
 };
 
+struct controlTestCase entryTestCases[] = {
+	QA_TEST("1. Entry OnChanged Callback", entryOnChanged),
+	QA_TEST("2. Password Entry OnChanged Callback", passwordEntryOnChanged),
+	QA_TEST("3. Search Entry OnChanged Callback", searchEntryOnChanged),
+	{NULL, NULL, NULL}
+};
+
 struct controlTestCase labelTestCases[] = {
 	QA_TEST("1. Multi Line", labelMultiLine),
 	{NULL, NULL, NULL}
@@ -33,6 +40,7 @@ struct controlTestCase labelTestCases[] = {
 struct controlTestGroup controlTestGroups[] = {
 	{"uiButton", buttonTestCases},
 	{"uiCheckbox", checkboxTestCases},
+	{"uiEntry", entryTestCases},
 	{"uiLabel", labelTestCases},
 };
 

--- a/test/qa/main.c
+++ b/test/qa/main.c
@@ -15,12 +15,18 @@ struct controlTestGroup {
 
 #define QA_TEST(desciption, name) { desciption, name, name##Guide }
 
+struct controlTestCase buttonTestCases[] = {
+	QA_TEST("1. Button OnClicked Callback", buttonOnClicked),
+	{NULL, NULL, NULL}
+};
+
 struct controlTestCase labelTestCases[] = {
 	QA_TEST("1. Multi Line", labelMultiLine),
 	{NULL, NULL, NULL}
 };
 
 struct controlTestGroup controlTestGroups[] = {
+	{"uiButton", buttonTestCases},
 	{"uiLabel", labelTestCases},
 };
 

--- a/test/qa/meson.build
+++ b/test/qa/meson.build
@@ -1,0 +1,23 @@
+libui_qa_sources = [
+	'qa.c',
+	'main.c',
+	'label.c',
+]
+
+if libui_OS == 'windows'
+	libui_qa_manifest = 'qa.manifest'
+	if libui_mode == 'static'
+		libui_qa_manifest = 'qa.static.manifest'
+	endif
+	libui_qa_sources += [
+		windows.compile_resources('resources.rc',
+			args: libui_manifest_args,
+			depend_files: [libui_qa_manifest]),
+	]
+endif
+
+executable('qa', libui_qa_sources,
+	dependencies: libui_binary_deps,
+	link_with: libui_libui,
+	gui_app: false,
+	install: false)

--- a/test/qa/meson.build
+++ b/test/qa/meson.build
@@ -2,6 +2,7 @@ libui_qa_sources = [
 	'qa.c',
 	'main.c',
 	'button.c',
+	'checkbox.c',
 	'label.c',
 ]
 

--- a/test/qa/meson.build
+++ b/test/qa/meson.build
@@ -1,6 +1,7 @@
 libui_qa_sources = [
 	'qa.c',
 	'main.c',
+	'button.c',
 	'label.c',
 ]
 

--- a/test/qa/meson.build
+++ b/test/qa/meson.build
@@ -3,6 +3,7 @@ libui_qa_sources = [
 	'main.c',
 	'button.c',
 	'checkbox.c',
+	'entry.c',
 	'label.c',
 ]
 

--- a/test/qa/qa.c
+++ b/test/qa/qa.c
@@ -1,0 +1,18 @@
+#include "qa.h"
+
+uiControl* qaMakeGuide(uiControl *c, const char *text)
+{
+	uiBox *hbox;
+	uiMultilineEntry *guide;
+
+	hbox = uiNewHorizontalBox();
+	uiBoxSetPadded(hbox, 1);
+	uiBoxAppend(hbox, c, 1);
+
+	guide = uiNewMultilineEntry();
+	uiMultilineEntrySetText(guide, text);
+	uiMultilineEntrySetReadOnly(guide, 1);
+	uiBoxAppend(hbox, uiControl(guide), 1);
+
+	return uiControl(hbox);
+}

--- a/test/qa/qa.h
+++ b/test/qa/qa.h
@@ -1,0 +1,13 @@
+#ifndef __LIBUI_QA_H__
+#define __LIBUI_QA_H__
+
+#include "../../ui.h"
+
+uiControl* qaMakeGuide(uiControl *c, const char *text);
+
+#define QA_DECLARE_TEST(name) uiControl* name(); const char *name##Guide()
+
+QA_DECLARE_TEST(labelMultiLine);
+
+#endif
+

--- a/test/qa/qa.h
+++ b/test/qa/qa.h
@@ -7,6 +7,8 @@ uiControl* qaMakeGuide(uiControl *c, const char *text);
 
 #define QA_DECLARE_TEST(name) uiControl* name(); const char *name##Guide()
 
+QA_DECLARE_TEST(buttonOnClicked);
+
 QA_DECLARE_TEST(labelMultiLine);
 
 #endif

--- a/test/qa/qa.h
+++ b/test/qa/qa.h
@@ -11,6 +11,10 @@ QA_DECLARE_TEST(buttonOnClicked);
 
 QA_DECLARE_TEST(checkboxOnToggled);
 
+QA_DECLARE_TEST(entryOnChanged);
+QA_DECLARE_TEST(passwordEntryOnChanged);
+QA_DECLARE_TEST(searchEntryOnChanged);
+
 QA_DECLARE_TEST(labelMultiLine);
 
 #endif

--- a/test/qa/qa.h
+++ b/test/qa/qa.h
@@ -9,6 +9,8 @@ uiControl* qaMakeGuide(uiControl *c, const char *text);
 
 QA_DECLARE_TEST(buttonOnClicked);
 
+QA_DECLARE_TEST(checkboxOnToggled);
+
 QA_DECLARE_TEST(labelMultiLine);
 
 #endif

--- a/test/qa/qa.manifest
+++ b/test/qa/qa.manifest
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assemblyIdentity
+    version="1.0.0.0"
+    processorArchitecture="*"
+    name="CompanyName.ProductName.YourApplication"
+    type="win32"
+/>
+<description>Your application description here.</description>
+<!-- do NOT include the comctl6 dependency here; this lets us find bugs related to theming -->
+<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+        <!--The ID below indicates application support for Windows Vista -->
+        <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+        <!--The ID below indicates application support for Windows 7 -->
+        <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+    </application>
+</compatibility>
+</assembly>
+

--- a/test/qa/qa.static.manifest
+++ b/test/qa/qa.static.manifest
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assemblyIdentity
+    version="1.0.0.0"
+    processorArchitecture="*"
+    name="CompanyName.ProductName.YourApplication"
+    type="win32"
+/>
+<description>Your application description here.</description>
+<!-- we DO need comctl6 in the static case -->
+<dependency>
+    <dependentAssembly>
+        <assemblyIdentity
+            type="win32"
+            name="Microsoft.Windows.Common-Controls"
+            version="6.0.0.0"
+            processorArchitecture="*"
+            publicKeyToken="6595b64144ccf1df"
+            language="*"
+        />
+    </dependentAssembly>
+</dependency>
+<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+        <!--The ID below indicates application support for Windows Vista -->
+        <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+        <!--The ID below indicates application support for Windows 7 -->
+        <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+    </application>
+</compatibility>
+</assembly>
+

--- a/test/qa/resources.rc
+++ b/test/qa/resources.rc
@@ -1,0 +1,11 @@
+// this is a UTF-8 file
+#pragma code_page(65001)
+
+// this is the Common Controls 6 manifest
+// TODO set up the string values here
+// 1 is the value of CREATEPROCESS_MANIFEST_RESOURCE_ID and 24 is the value of RT_MANIFEST; we use it directly to avoid needing to share winapi.h with the tests and examples
+#ifndef _UI_STATIC
+1 24 "qa.manifest"
+#else
+1 24 "qa.static.manifest"
+#endif


### PR DESCRIPTION
This is something that came up with the uiLabel multi line support for windows: a manual testing app.

I believe this to be useful for visual inspection as well as things we can not automate through a11y APIs.

I am aware the tester currently does that. The problem I have with the tester right now is: I have little to no idea what I should expect, unless I dig into the code of each component.

This here is an attempt to have a formal testing application for quality assurance (QA). This is something everybody can run to verify the workings of the library and have a more structured approach to reporting bugs. I think this would also be very helpful for identifying possible regressions in new PRs.

I am aware it will be a very complex task to complete the QA tester, but to be honest, it will be worth it. Working on the table selection API I already identified numerous upstream bugs through manual testing procedures (which I will make available soon).

Happy for feedback, especially with regards to the wording of the upstream bug reporting procedure on the `Quality Assurance` tab.