### PR TITLE
test: Fix unit test for uiLabel to match description.

### DIFF
--- a/test/unit/label.c
+++ b/test/unit/label.c
@@ -13,7 +13,7 @@ static void labelNewEmptyString(void **state)
 {
 	uiLabel **l = uiLabelPtrFromState(state);
 
-	*l = uiNewLabel("Text");
+	*l = uiNewLabel("");
 }
 
 static void labelText(void **state)


### PR DESCRIPTION
The `labelNewEmptyString` does the same as the exact same thing as `labelNew`, whereas it was supposed to test empty string. This patch fixes that.