### PR TITLE
Add unit tests for uiCombobox and fix unix and darwin bugs.

### DIFF
--- a/darwin/combobox.m
+++ b/darwin/combobox.m
@@ -79,16 +79,34 @@ static void uiComboboxDestroy(uiControl *cc)
 void uiComboboxAppend(uiCombobox *c, const char *text)
 {
 	[c->pbac addObject:uiprivToNSString(text)];
+	uiControlEnable(uiControl(c));
 }
 
 void uiComboboxInsertAt(uiCombobox *c, int n, const char *text)
 {
+	int selected = uiComboboxSelected(c);
+
 	[c->pbac insertObject:uiprivToNSString(text) atArrangedObjectIndex:n];
+	uiControlEnable(uiControl(c));
+
+	if (n <= selected)
+		uiComboboxSetSelected(c, selected+1);
+	else
+		uiComboboxSetSelected(c, selected);
 }
 
 void uiComboboxDelete(uiCombobox *c, int n)
 {
+	int selected = uiComboboxSelected(c);
+
 	[c->pbac removeObjectAtArrangedObjectIndex:n];
+
+	if (n < selected)
+		uiComboboxSetSelected(c, selected-1);
+	if (uiComboboxNumItems(c) == 0) {
+		uiControlDisable(uiControl(c));
+		uiComboboxSetSelected(c, -1);
+	}
 }
 
 void uiComboboxClear(uiCombobox *c)
@@ -98,6 +116,8 @@ void uiComboboxClear(uiCombobox *c)
 			// remove all items
 			return TRUE;
 	}]];
+	uiComboboxSetSelected(c, -1);
+	uiControlDisable(uiControl(c));
 }
 
 int uiComboboxNumItems(uiCombobox *c)
@@ -164,6 +184,8 @@ uiCombobox *uiNewCombobox(void)
 	}
 	[comboboxDelegate registerCombobox:c];
 	uiComboboxOnSelected(c, defaultOnSelected, NULL);
+	uiComboboxSetSelected(c, -1);
+	uiControlDisable(uiControl(c));
 
 	return c;
 }

--- a/test/unit/combobox.c
+++ b/test/unit/combobox.c
@@ -43,6 +43,20 @@ static void comboboxAppend(void **state)
 	assert_int_equal(uiComboboxNumItems(*c), 2);
 }
 
+static void comboboxAppendDuplicate(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+	const char *duplicate = "Duplicate";
+
+	*c = uiNewCombobox();
+
+	uiComboboxAppend(*c, duplicate);
+	uiComboboxAppend(*c, duplicate);
+	//TODO assert_string_equal(uiComboboxAt(*c, 0), duplicate);
+	//TODO assert_string_equal(uiComboboxAt(*c, 1), duplicate);
+	assert_int_equal(uiComboboxNumItems(*c), 2);
+}
+
 static void comboboxSetSelected(void **state)
 {
 	uiCombobox **c = uiComboboxPtrFromState(state);
@@ -96,6 +110,20 @@ static void comboboxInsertAt(void **state)
 	//TODO assert_string_equal(uiComboboxAt(*c, 3), item3);
 	assert_int_equal(uiComboboxNumItems(*c), 4);
 	assert_int_equal(uiComboboxSelected(*c), 2);
+}
+
+static void comboboxInsertAtDuplicate(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+	const char *duplicate = "Duplicate";
+
+	*c = uiNewCombobox();
+
+	uiComboboxInsertAt(*c, 0, duplicate);
+	uiComboboxInsertAt(*c, 1, duplicate);
+	//TODO assert_string_equal(uiComboboxAt(*c, 0), duplicate);
+	//TODO assert_string_equal(uiComboboxAt(*c, 1), duplicate);
+	assert_int_equal(uiComboboxNumItems(*c), 2);
 }
 
 static void comboboxClearEmpty(void **state)
@@ -268,8 +296,10 @@ int comboboxRunUnitTests(void)
 		comboboxUnitTest(comboboxNumItemsDefault),
 		comboboxUnitTest(comboboxSelectedDefault),
 		comboboxUnitTest(comboboxAppend),
+		comboboxUnitTest(comboboxAppendDuplicate),
 		comboboxUnitTest(comboboxSetSelected),
 		comboboxUnitTest(comboboxInsertAt),
+		comboboxUnitTest(comboboxInsertAtDuplicate),
 		comboboxUnitTest(comboboxClearEmpty),
 		comboboxUnitTest(comboboxClear),
 		comboboxUnitTest(comboboxClearAppend),

--- a/test/unit/combobox.c
+++ b/test/unit/combobox.c
@@ -1,0 +1,285 @@
+#include "unit.h"
+
+#define uiComboboxPtrFromState(s) uiControlPtrFromState(uiCombobox, s)
+
+static void comboboxNew(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+
+	*c = uiNewCombobox();
+}
+
+static void comboboxNumItemsDefault(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+
+	*c = uiNewCombobox();
+	assert_int_equal(uiComboboxNumItems(*c), 0);
+}
+
+static void comboboxSelectedDefault(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+
+	*c = uiNewCombobox();
+	assert_int_equal(uiComboboxSelected(*c), -1);
+}
+
+static void comboboxAppend(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+	const char *item0 = "Item 0";
+	const char *item1 = "Item 1";
+
+	*c = uiNewCombobox();
+
+	uiComboboxAppend(*c, item0);
+	//TODO assert_string_equal(uiComboboxAt(*c, 0), item0);
+	assert_int_equal(uiComboboxNumItems(*c), 1);
+
+	uiComboboxAppend(*c, item1);
+	//TODO assert_string_equal(uiComboboxAt(*c, 0), item0);
+	//TODO assert_string_equal(uiComboboxAt(*c, 1), item1);
+	assert_int_equal(uiComboboxNumItems(*c), 2);
+}
+
+static void comboboxSetSelected(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+
+	*c = uiNewCombobox();
+	uiComboboxAppend(*c, "Item 0");
+	uiComboboxAppend(*c, "Item 1");
+
+	uiComboboxSetSelected(*c, 1);
+	assert_int_equal(uiComboboxSelected(*c), 1);
+
+	uiComboboxSetSelected(*c, 0);
+	assert_int_equal(uiComboboxSelected(*c), 0);
+
+	uiComboboxSetSelected(*c, -1);
+	assert_int_equal(uiComboboxSelected(*c), -1);
+}
+
+static void comboboxInsertAt(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+	const char *item0 = "Item 0";
+	const char *item1 = "Item 1";
+	const char *item2 = "Item 2";
+	const char *item3 = "Item 3";
+
+	*c = uiNewCombobox();
+
+	uiComboboxInsertAt(*c, 0, item0);
+	//TODO assert_string_equal(uiComboboxAt(*c, 0), item0);
+	assert_int_equal(uiComboboxNumItems(*c), 1);
+	uiComboboxSetSelected(*c, 0);
+
+	uiComboboxInsertAt(*c, 0, item1);
+	//TODO assert_string_equal(uiComboboxAt(*c, 0), item1);
+	//TODO assert_string_equal(uiComboboxAt(*c, 1), item0);
+	assert_int_equal(uiComboboxNumItems(*c), 2);
+	assert_int_equal(uiComboboxSelected(*c), 1);
+
+	uiComboboxInsertAt(*c, 1, item2);
+	//TODO assert_string_equal(uiComboboxAt(*c, 0), item1);
+	//TODO assert_string_equal(uiComboboxAt(*c, 1), item2);
+	//TODO assert_string_equal(uiComboboxAt(*c, 2), item0);
+	assert_int_equal(uiComboboxNumItems(*c), 3);
+	assert_int_equal(uiComboboxSelected(*c), 2);
+
+	uiComboboxInsertAt(*c, 3, item3);
+	//TODO assert_string_equal(uiComboboxAt(*c, 0), item1);
+	//TODO assert_string_equal(uiComboboxAt(*c, 1), item2);
+	//TODO assert_string_equal(uiComboboxAt(*c, 2), item0);
+	//TODO assert_string_equal(uiComboboxAt(*c, 3), item3);
+	assert_int_equal(uiComboboxNumItems(*c), 4);
+	assert_int_equal(uiComboboxSelected(*c), 2);
+}
+
+static void comboboxClearEmpty(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+
+	*c = uiNewCombobox();
+
+	uiComboboxClear(*c);
+	assert_int_equal(uiComboboxNumItems(*c), 0);
+	assert_int_equal(uiComboboxSelected(*c), -1);
+
+	uiComboboxClear(*c);
+	assert_int_equal(uiComboboxNumItems(*c), 0);
+	assert_int_equal(uiComboboxSelected(*c), -1);
+}
+
+static void comboboxClear(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+
+	*c = uiNewCombobox();
+	uiComboboxAppend(*c, "Item 0");
+	uiComboboxAppend(*c, "Item 1");
+	assert_int_equal(uiComboboxNumItems(*c), 2);
+	uiComboboxSetSelected(*c, 1);
+
+	uiComboboxClear(*c);
+	assert_int_equal(uiComboboxNumItems(*c), 0);
+	assert_int_equal(uiComboboxSelected(*c), -1);
+}
+
+static void comboboxClearAppend(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+
+	*c = uiNewCombobox();
+	uiComboboxAppend(*c, "Item 0");
+	uiComboboxAppend(*c, "Item 1");
+	assert_int_equal(uiComboboxNumItems(*c), 2);
+
+	uiComboboxClear(*c);
+	assert_int_equal(uiComboboxNumItems(*c), 0);
+	uiComboboxAppend(*c, "Item 2");
+	uiComboboxAppend(*c, "Item 3");
+	assert_int_equal(uiComboboxNumItems(*c), 2);
+}
+
+static void comboboxDelete(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+	const char *item0 = "Item 0";
+	const char *item1 = "Item 1";
+	const char *item2 = "Item 2";
+
+	*c = uiNewCombobox();
+	uiComboboxAppend(*c, item0);
+	uiComboboxAppend(*c, item1);
+	uiComboboxAppend(*c, item2);
+	uiComboboxSetSelected(*c, 1);
+
+	uiComboboxDelete(*c, 0);
+	//TODO assert_string_equal(uiComboboxAt(*c, 0), item1);
+	//TODO assert_string_equal(uiComboboxAt(*c, 1), item2);
+	assert_int_equal(uiComboboxNumItems(*c), 2);
+	assert_int_equal(uiComboboxSelected(*c), 0);
+
+	uiComboboxDelete(*c, 1);
+	//TODO assert_string_equal(uiComboboxAt(*c, 0), item1);
+	assert_int_equal(uiComboboxNumItems(*c), 1);
+	assert_int_equal(uiComboboxSelected(*c), 0);
+
+	uiComboboxDelete(*c, 0);
+	assert_int_equal(uiComboboxNumItems(*c), 0);
+	assert_int_equal(uiComboboxSelected(*c), -1);
+}
+
+
+static void onChangedNoCall(uiCombobox *c, void *data)
+{
+	function_called();
+}
+
+static void comboboxSetSelectedNoCallback(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+
+	*c = uiNewCombobox();
+	uiComboboxOnSelected(*c, onChangedNoCall, NULL);
+	uiComboboxAppend(*c, "Item 0");
+	uiComboboxAppend(*c, "Item 1");
+	// FIXME: https://gitlab.com/cmocka/cmocka/-/issues/18
+	//expect_function_calls(onChangedNoCall, 0);
+
+	uiComboboxSetSelected(*c, 1);
+	uiComboboxSetSelected(*c, 0);
+}
+
+
+static void comboboxInsertAtNoCallback(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+
+	*c = uiNewCombobox();
+	uiComboboxOnSelected(*c, onChangedNoCall, NULL);
+	// FIXME: https://gitlab.com/cmocka/cmocka/-/issues/18
+	//expect_function_calls(onChangedNoCall, 0);
+
+	uiComboboxInsertAt(*c, 0, "Item 0");
+	uiComboboxSetSelected(*c, 0);
+	uiComboboxInsertAt(*c, 0, "Item 1");
+	uiComboboxInsertAt(*c, 1, "Item 2");
+}
+
+static void comboboxClearEmptyNoCallback(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+
+	*c = uiNewCombobox();
+	uiComboboxOnSelected(*c, onChangedNoCall, NULL);
+	// FIXME: https://gitlab.com/cmocka/cmocka/-/issues/18
+	//expect_function_calls(onChangedNoCall, 0);
+
+	uiComboboxClear(*c);
+}
+
+static void comboboxClearNoCallback(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+
+	*c = uiNewCombobox();
+	uiComboboxOnSelected(*c, onChangedNoCall, NULL);
+	// FIXME: https://gitlab.com/cmocka/cmocka/-/issues/18
+	//expect_function_calls(onChangedNoCall, 0);
+	uiComboboxAppend(*c, "Item 0");
+	uiComboboxAppend(*c, "Item 1");
+
+	uiComboboxClear(*c);
+	uiComboboxAppend(*c, "Item 2");
+	uiComboboxSetSelected(*c, 0);
+	uiComboboxClear(*c);
+}
+
+static void comboboxDeleteNoCallback(void **state)
+{
+	uiCombobox **c = uiComboboxPtrFromState(state);
+
+	*c = uiNewCombobox();
+	uiComboboxOnSelected(*c, onChangedNoCall, NULL);
+	// FIXME: https://gitlab.com/cmocka/cmocka/-/issues/18
+	//expect_function_calls(onChangedNoCall, 0);
+	uiComboboxAppend(*c, "Item 0");
+	uiComboboxAppend(*c, "Item 1");
+	uiComboboxAppend(*c, "Item 2");
+
+	uiComboboxDelete(*c, 0);
+	uiComboboxSetSelected(*c, 1);
+	uiComboboxDelete(*c, 1);
+	uiComboboxDelete(*c, 0);
+}
+
+#define comboboxUnitTest(f) cmocka_unit_test_setup_teardown((f), \
+		unitTestSetup, unitTestTeardown)
+
+int comboboxRunUnitTests(void)
+{
+	const struct CMUnitTest tests[] = {
+		comboboxUnitTest(comboboxNew),
+		comboboxUnitTest(comboboxNumItemsDefault),
+		comboboxUnitTest(comboboxSelectedDefault),
+		comboboxUnitTest(comboboxAppend),
+		comboboxUnitTest(comboboxSetSelected),
+		comboboxUnitTest(comboboxInsertAt),
+		comboboxUnitTest(comboboxClearEmpty),
+		comboboxUnitTest(comboboxClear),
+		comboboxUnitTest(comboboxClearAppend),
+		comboboxUnitTest(comboboxDelete),
+		comboboxUnitTest(comboboxSetSelectedNoCallback),
+		comboboxUnitTest(comboboxInsertAtNoCallback),
+		comboboxUnitTest(comboboxClearNoCallback),
+		comboboxUnitTest(comboboxClearEmptyNoCallback),
+		comboboxUnitTest(comboboxDeleteNoCallback),
+	};
+
+	return cmocka_run_group_tests_name("uiCombobox", tests, unitTestsSetup, unitTestsTeardown);
+}
+

--- a/test/unit/combobox.c
+++ b/test/unit/combobox.c
@@ -163,11 +163,12 @@ static void comboboxDelete(void **state)
 	assert_int_equal(uiComboboxNumItems(*c), 2);
 	assert_int_equal(uiComboboxSelected(*c), 0);
 
-	uiComboboxDelete(*c, 1);
-	//TODO assert_string_equal(uiComboboxAt(*c, 0), item1);
+	uiComboboxDelete(*c, 0);
+	//TODO assert_string_equal(uiComboboxAt(*c, 0), item2);
 	assert_int_equal(uiComboboxNumItems(*c), 1);
-	assert_int_equal(uiComboboxSelected(*c), 0);
+	assert_int_equal(uiComboboxSelected(*c), -1);
 
+	uiComboboxSetSelected(*c, 0);
 	uiComboboxDelete(*c, 0);
 	assert_int_equal(uiComboboxNumItems(*c), 0);
 	assert_int_equal(uiComboboxSelected(*c), -1);

--- a/test/unit/combobox.c
+++ b/test/unit/combobox.c
@@ -41,6 +41,8 @@ static void comboboxAppend(void **state)
 	//TODO assert_string_equal(uiComboboxAt(*c, 0), item0);
 	//TODO assert_string_equal(uiComboboxAt(*c, 1), item1);
 	assert_int_equal(uiComboboxNumItems(*c), 2);
+
+	assert_int_equal(uiComboboxSelected(*c), -1);
 }
 
 static void comboboxAppendDuplicate(void **state)
@@ -88,6 +90,8 @@ static void comboboxInsertAt(void **state)
 	uiComboboxInsertAt(*c, 0, item0);
 	//TODO assert_string_equal(uiComboboxAt(*c, 0), item0);
 	assert_int_equal(uiComboboxNumItems(*c), 1);
+	assert_int_equal(uiComboboxSelected(*c), -1);
+
 	uiComboboxSetSelected(*c, 0);
 
 	uiComboboxInsertAt(*c, 0, item1);

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -72,6 +72,7 @@ int main(void)
 		{ spinboxRunUnitTests },
 		{ labelRunUnitTests },
 		{ buttonRunUnitTests },
+		{ comboboxRunUnitTests },
 	};
 
 	for (i = 0; i < sizeof(unitTests)/sizeof(*unitTests); ++i) {

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -8,6 +8,7 @@ libui_unit_sources = [
         'spinbox.c',
         'label.c',
         'button.c',
+        'combobox.c',
 ]
 
 if libui_OS == 'windows'

--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -18,6 +18,7 @@ int sliderRunUnitTests(void);
 int spinboxRunUnitTests(void);
 int labelRunUnitTests(void);
 int buttonRunUnitTests(void);
+int comboboxRunUnitTests(void);
 
 /**
  * Helper for general setup/teardown of controls embedded in a window.

--- a/ui.h
+++ b/ui.h
@@ -1330,7 +1330,7 @@ _UI_EXTERN int uiComboboxNumItems(uiCombobox *c);
  * Returns the index of the item selected.
  *
  * @param c uiCombobox instance.
- * @returns Index of the item selected, `-1` on empty selection.
+ * @returns Index of the item selected, `-1` on empty selection. [Default `-1`]
  * @memberof uiCombobox
  */
 _UI_EXTERN int uiComboboxSelected(uiCombobox *c);

--- a/ui.h
+++ b/ui.h
@@ -1353,7 +1353,8 @@ _UI_EXTERN void uiComboboxSetSelected(uiCombobox *c, int index);
  *          @p senderData User data registered with the sender instance.
  * @param data User data to be passed to the callback.
  *
- * @note The callback is not triggered when calling uiComboboxSetSelected().
+ * @note The callback is not triggered when calling uiComboboxSetSelected(),
+ *       uiComboboxInsertAt(), uiComboboxDelete(), or uiComboboxClear().
  * @note Only one callback can be registered at a time.
  * @memberof uiCombobox
  */

--- a/ui.h
+++ b/ui.h
@@ -1303,6 +1303,9 @@ _UI_EXTERN void uiComboboxInsertAt(uiCombobox *c, int index, const char *text);
 /**
  * Deletes an item at @p index from the combo box.
  *
+ * @note Deleting the index of the item currently selected will move the
+ * selection to the next item in the combo box or `-1` if no such item exists.
+ *
  * @param c uiCombobox instance.
  * @param index Index of the item to be deleted.
  * @memberof uiCombobox

--- a/unix/combobox.c
+++ b/unix/combobox.c
@@ -44,7 +44,9 @@ void uiComboboxDelete(uiCombobox *c, int n)
 
 void uiComboboxClear(uiCombobox *c)
 {
+	g_signal_handler_block(c->combobox, c->onSelectedSignal);
 	gtk_combo_box_text_remove_all(c->comboboxText);
+	g_signal_handler_unblock(c->combobox, c->onSelectedSignal);
 }
 
 int uiComboboxNumItems(uiCombobox *c)

--- a/unix/combobox.c
+++ b/unix/combobox.c
@@ -37,7 +37,9 @@ void uiComboboxInsertAt(uiCombobox *c, int n, const char *text)
 
 void uiComboboxDelete(uiCombobox *c, int n)
 {
+	g_signal_handler_block(c->combobox, c->onSelectedSignal);
 	gtk_combo_box_text_remove(c->comboboxText, n);
+	g_signal_handler_unblock(c->combobox, c->onSelectedSignal);
 }
 
 void uiComboboxClear(uiCombobox *c)


### PR DESCRIPTION
Add unit tests for uiCombobox and fix the inconsistent triggering of `uiComboboxOnSelected` on unix platforms.

Again some may be considered upstream Gtk bugs (clearing an empty combobox with no selection triggers an `OnSelected` signal) but others are not (by the Gtk idea of when to trigger signals). I'm still planing to report these upstream but from my other reports (including patches) feedback has been nonexistent. As the fixes are the same anyways, here the fixes.