### PR TITLE
Update entry.cpp and multilineentry.cpp on Windows

### DIFF
--- a/windows/entry.cpp
+++ b/windows/entry.cpp
@@ -68,7 +68,7 @@ void uiEntrySetText(uiEntry *e, const char *text)
 	e->inhibitChanged = TRUE;
 	uiWindowsSetWindowText(e->hwnd, text);
 	l = (int)strlen(text);
-	SendMessage(e->hwnd, EM_SETSEL, l, l);
+	Edit_SetSel(e->hwnd, l, l);
 	e->inhibitChanged = FALSE;
 	// don't queue the control for resize; entry sizes are independent of their contents
 }
@@ -86,13 +86,8 @@ int uiEntryReadOnly(uiEntry *e)
 
 void uiEntrySetReadOnly(uiEntry *e, int readonly)
 {
-	WPARAM ro;
-
-	ro = (WPARAM) FALSE;
-	if (readonly)
-		ro = (WPARAM) TRUE;
-	if (SendMessage(e->hwnd, EM_SETREADONLY, ro, 0) == 0)
-		logLastError(L"error making uiEntry read-only");
+	if (Edit_SetReadOnly(e->hwnd, readonly) == 0)
+		logLastError(L"error setting uiEntry read-only state");
 }
 
 static uiEntry *finishNewEntry(DWORD style)

--- a/windows/multilineentry.cpp
+++ b/windows/multilineentry.cpp
@@ -83,12 +83,16 @@ void uiMultilineEntrySetText(uiMultilineEntry *e, const char *text)
 
 void uiMultilineEntryAppend(uiMultilineEntry *e, const char *text)
 {
+	DWORD selStart, selEnd;
 	LRESULT l;
 	char *crlf;
 	WCHAR *wtext;
 
 	// doing this raises an EN_CHANGED
 	e->inhibitChanged = TRUE;
+
+	// Save current selection
+	SendMessageW(e->hwnd, EM_GETSEL, (WPARAM) &selStart, (LPARAM) &selEnd);
 	// Append by replacing an empty selection at the end of the input
 	l = SendMessageW(e->hwnd, WM_GETTEXTLENGTH, 0, 0);
 	Edit_SetSel(e->hwnd, l, l);
@@ -97,6 +101,9 @@ void uiMultilineEntryAppend(uiMultilineEntry *e, const char *text)
 	uiprivFree(crlf);
 	Edit_ReplaceSel(e->hwnd, wtext);
 	uiprivFree(wtext);
+	// Restore selection
+	Edit_SetSel(e->hwnd, selStart, selEnd);
+
 	e->inhibitChanged = FALSE;
 }
 


### PR DESCRIPTION
I'm not sure if it is better etiquette to make individual PRs for each of my suggested changes, but there are multiple small changes so I decided to group them into a single PR.

https://github.com/norepimorphism/libui-ng/blob/7b9380b17692807bb5a4164213d01018ab2f7c6c/windows/entry.cpp#L16-L23

Here, I made a small refactor to make the branches taken a little more clear. I made the same change in `multilineentry.cpp`.

https://github.com/norepimorphism/libui-ng/blob/7b9380b17692807bb5a4164213d01018ab2f7c6c/windows/entry.cpp#L71

Here, I replaced a `PostMessageW` call with the corresponding macro: in this case, `Edit_SetSel`. I believe switching from `PostMessageW` to macros where possible was mentioned previously as an issue.

https://github.com/norepimorphism/libui-ng/blob/7b9380b17692807bb5a4164213d01018ab2f7c6c/windows/entry.cpp#L89-L90

This should be equivalent to the original code but is a little less verbose.

https://github.com/norepimorphism/libui-ng/blob/7b9380b17692807bb5a4164213d01018ab2f7c6c/windows/multilineentry.cpp#L84-L107

I made a few changes here. Mainly, I addressed the comments left previously by preserving the current text selection after appending text. I also made a few macro replacements where possible, and I introduced a new function `windowTextLen` in `text.cpp` that returns the text length of an edit control. I noticed we were querying text length manually in some places, so I decided to make a dedicated function.