### PR TITLE
Impl. DPI awareness on Windows

### DIFF
--- a/examples/example.manifest
+++ b/examples/example.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
 <assemblyIdentity
     version="1.0.0.0"
     processorArchitecture="*"
@@ -14,7 +14,17 @@
         <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
         <!--The ID below indicates application support for Windows 7 -->
         <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+        <!--The ID below indicates application support for Windows 10+ -->
+        <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
 </compatibility>
+<asmv3:application>
+    <asmv3:windowsSettings>
+        <!-- supported on Windows Vista and above -->
+        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+        <!-- supported on Windows 10 and above -->
+        <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+</asmv3:application>
 </assembly>
 

--- a/examples/example.static.manifest
+++ b/examples/example.static.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
 <assemblyIdentity
     version="1.0.0.0"
     processorArchitecture="*"
@@ -7,8 +7,8 @@
     type="win32"
 />
 <description>Your application description here.</description>
-<!-- we DO need comctl6 in the static case -->
 <dependency>
+    <!-- we DO need comctl6 in the static case -->
     <dependentAssembly>
         <assemblyIdentity
             type="win32"
@@ -26,7 +26,17 @@
         <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
         <!--The ID below indicates application support for Windows 7 -->
         <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+        <!--The ID below indicates application support for Windows 10+ -->
+        <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
 </compatibility>
+<asmv3:application>
+    <asmv3:windowsSettings>
+        <!-- supported on Windows Vista and above -->
+        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+        <!-- supported on Windows 10 and above -->
+        <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+</asmv3:application>
 </assembly>
 

--- a/test/test.manifest
+++ b/test/test.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
 <assemblyIdentity
     version="1.0.0.0"
     processorArchitecture="*"
@@ -14,7 +14,17 @@
         <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
         <!--The ID below indicates application support for Windows 7 -->
         <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+        <!--The ID below indicates application support for Windows 10+ -->
+        <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
 </compatibility>
+<asmv3:application>
+    <asmv3:windowsSettings>
+        <!-- supported on Windows Vista and above -->
+        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+        <!-- supported on Windows 10 and above -->
+        <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+</asmv3:application>
 </assembly>
 

--- a/test/test.static.manifest
+++ b/test/test.static.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
 <assemblyIdentity
     version="1.0.0.0"
     processorArchitecture="*"
@@ -7,8 +7,8 @@
     type="win32"
 />
 <description>Your application description here.</description>
-<!-- we DO need comctl6 in the static case -->
 <dependency>
+    <!-- we DO need comctl6 in the static case -->
     <dependentAssembly>
         <assemblyIdentity
             type="win32"
@@ -26,7 +26,17 @@
         <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
         <!--The ID below indicates application support for Windows 7 -->
         <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+        <!--The ID below indicates application support for Windows 10+ -->
+        <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
 </compatibility>
+<asmv3:application>
+    <asmv3:windowsSettings>
+        <!-- supported on Windows Vista and above -->
+        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+        <!-- supported on Windows 10 and above -->
+        <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+</asmv3:application>
 </assembly>
 

--- a/test/unit/unit.manifest
+++ b/test/unit/unit.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
 <assemblyIdentity
     version="1.0.0.0"
     processorArchitecture="*"
@@ -14,7 +14,17 @@
         <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
         <!--The ID below indicates application support for Windows 7 -->
         <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+        <!--The ID below indicates application support for Windows 10+ -->
+        <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
 </compatibility>
+<asmv3:application>
+    <asmv3:windowsSettings>
+        <!-- supported on Windows Vista and above -->
+        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+        <!-- supported on Windows 10 and above -->
+        <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+</asmv3:application>
 </assembly>
 

--- a/test/unit/unit.static.manifest
+++ b/test/unit/unit.static.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
 <assemblyIdentity
     version="1.0.0.0"
     processorArchitecture="*"
@@ -7,8 +7,8 @@
     type="win32"
 />
 <description>Your application description here.</description>
-<!-- we DO need comctl6 in the static case -->
 <dependency>
+    <!-- we DO need comctl6 in the static case -->
     <dependentAssembly>
         <assemblyIdentity
             type="win32"
@@ -26,7 +26,17 @@
         <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
         <!--The ID below indicates application support for Windows 7 -->
         <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+        <!--The ID below indicates application support for Windows 10+ -->
+        <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
 </compatibility>
+<asmv3:application>
+    <asmv3:windowsSettings>
+        <!-- supported on Windows Vista and above -->
+        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+        <!-- supported on Windows 10 and above -->
+        <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+</asmv3:application>
 </assembly>
 

--- a/windows/_rc2bin/libui.manifest
+++ b/windows/_rc2bin/libui.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
 <assemblyIdentity
     version="1.0.0.0"
     processorArchitecture="*"
@@ -25,7 +25,17 @@
         <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
         <!--The ID below indicates application support for Windows 7 -->
         <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+        <!--The ID below indicates application support for Windows 10+ -->
+        <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
 </compatibility>
+<asmv3:application>
+    <asmv3:windowsSettings>
+        <!-- supported on Windows Vista and above -->
+        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+        <!-- supported on Windows 10 and above -->
+        <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+</asmv3:application>
 </assembly>
 

--- a/windows/colorbutton.cpp
+++ b/windows/colorbutton.cpp
@@ -58,9 +58,11 @@ static BOOL onWM_NOTIFY(uiControl *c, HWND hwnd, NMHDR *nmhdr, LRESULT *lResult)
 	D2D1_RECT_F r;
 	D2D1_COLOR_F color;
 	D2D1_BRUSH_PROPERTIES bprop;
+	D2D1_MATRIX_3X2_F dm;
 	ID2D1SolidColorBrush *brush;
 	uiWindowsSizing sizing;
 	int x, y;
+	float dpi_x, dpi_y;
 	HRESULT hr;
 
 	if (nmhdr->code != NM_CUSTOMDRAW)
@@ -72,6 +74,17 @@ static BOOL onWM_NOTIFY(uiControl *c, HWND hwnd, NMHDR *nmhdr, LRESULT *lResult)
 	uiWindowsEnsureGetClientRect(b->hwnd, &client);
 	rt = makeHDCRenderTarget(nm->hdc, &client);
 	rt->BeginDraw();
+
+	rt->GetDpi(&dpi_x, &dpi_y);
+	ZeroMemory(&dm, sizeof (D2D1_MATRIX_3X2_F));
+
+	// scale by the ratio of Windows' assumed DPI (96) to the actual DPI
+
+	// m11 is horizontal scaling
+	dm.m11 = 96.f / dpi_x;
+	// m22 is vertical scaling
+	dm.m22 = 96.f / dpi_y;
+	rt->SetTransform(&dm);
 
 	uiWindowsGetSizing(b->hwnd, &sizing);
 	x = 3;		// should be enough

--- a/windows/draw.cpp
+++ b/windows/draw.cpp
@@ -26,18 +26,28 @@ ID2D1HwndRenderTarget *makeHWNDRenderTarget(HWND hwnd)
 {
 	D2D1_RENDER_TARGET_PROPERTIES props;
 	D2D1_HWND_RENDER_TARGET_PROPERTIES hprops;
+	HDC dc;
 	RECT r;
 	ID2D1HwndRenderTarget *rt;
 	HRESULT hr;
+
+	// we need a DC for the DPI
+	// we *could* just use the screen DPI but why when we have a window handle and its DC has a DPI
+	dc = GetDC(hwnd);
+	if (dc == NULL)
+		logLastError(L"error getting DC to find DPI");
 
 	ZeroMemory(&props, sizeof (D2D1_RENDER_TARGET_PROPERTIES));
 	props.type = D2D1_RENDER_TARGET_TYPE_DEFAULT;
 	props.pixelFormat.format = DXGI_FORMAT_UNKNOWN;
 	props.pixelFormat.alphaMode = D2D1_ALPHA_MODE_UNKNOWN;
-	props.dpiX = 0;
-	props.dpiY = 0;
+	props.dpiX = GetDeviceCaps(dc, LOGPIXELSX);
+	props.dpiY = GetDeviceCaps(dc, LOGPIXELSY);
 	props.usage = D2D1_RENDER_TARGET_USAGE_NONE;
 	props.minLevel = D2D1_FEATURE_LEVEL_DEFAULT;
+
+	if (ReleaseDC(hwnd, dc) == 0)
+		logLastError(L"error releasing DC for finding DPI");
 
 	uiWindowsEnsureGetClientRect(hwnd, &r);
 
@@ -67,9 +77,8 @@ ID2D1DCRenderTarget *makeHDCRenderTarget(HDC dc, RECT *r)
 	props.type = D2D1_RENDER_TARGET_TYPE_DEFAULT;
 	props.pixelFormat.format = DXGI_FORMAT_B8G8R8A8_UNORM;
 	props.pixelFormat.alphaMode = D2D1_ALPHA_MODE_PREMULTIPLIED;
-	// use default DPI
-	props.dpiX = 0;
-	props.dpiY = 0;
+	props.dpiX = GetDeviceCaps(dc, LOGPIXELSX);
+	props.dpiY = GetDeviceCaps(dc, LOGPIXELSY);
 	props.usage = D2D1_RENDER_TARGET_USAGE_GDI_COMPATIBLE;
 	props.minLevel = D2D1_FEATURE_LEVEL_DEFAULT;
 

--- a/windows/draw.cpp
+++ b/windows/draw.cpp
@@ -26,28 +26,18 @@ ID2D1HwndRenderTarget *makeHWNDRenderTarget(HWND hwnd)
 {
 	D2D1_RENDER_TARGET_PROPERTIES props;
 	D2D1_HWND_RENDER_TARGET_PROPERTIES hprops;
-	HDC dc;
 	RECT r;
 	ID2D1HwndRenderTarget *rt;
 	HRESULT hr;
-
-	// we need a DC for the DPI
-	// we *could* just use the screen DPI but why when we have a window handle and its DC has a DPI
-	dc = GetDC(hwnd);
-	if (dc == NULL)
-		logLastError(L"error getting DC to find DPI");
 
 	ZeroMemory(&props, sizeof (D2D1_RENDER_TARGET_PROPERTIES));
 	props.type = D2D1_RENDER_TARGET_TYPE_DEFAULT;
 	props.pixelFormat.format = DXGI_FORMAT_UNKNOWN;
 	props.pixelFormat.alphaMode = D2D1_ALPHA_MODE_UNKNOWN;
-	props.dpiX = GetDeviceCaps(dc, LOGPIXELSX);
-	props.dpiY = GetDeviceCaps(dc, LOGPIXELSY);
+	props.dpiX = 0;
+	props.dpiY = 0;
 	props.usage = D2D1_RENDER_TARGET_USAGE_NONE;
 	props.minLevel = D2D1_FEATURE_LEVEL_DEFAULT;
-
-	if (ReleaseDC(hwnd, dc) == 0)
-		logLastError(L"error releasing DC for finding DPI");
 
 	uiWindowsEnsureGetClientRect(hwnd, &r);
 
@@ -77,8 +67,9 @@ ID2D1DCRenderTarget *makeHDCRenderTarget(HDC dc, RECT *r)
 	props.type = D2D1_RENDER_TARGET_TYPE_DEFAULT;
 	props.pixelFormat.format = DXGI_FORMAT_B8G8R8A8_UNORM;
 	props.pixelFormat.alphaMode = D2D1_ALPHA_MODE_PREMULTIPLIED;
-	props.dpiX = GetDeviceCaps(dc, LOGPIXELSX);
-	props.dpiY = GetDeviceCaps(dc, LOGPIXELSY);
+	// use default DPI
+	props.dpiX = 0;
+	props.dpiY = 0;
 	props.usage = D2D1_RENDER_TARGET_USAGE_GDI_COMPATIBLE;
 	props.minLevel = D2D1_FEATURE_LEVEL_DEFAULT;
 

--- a/windows/init.cpp
+++ b/windows/init.cpp
@@ -71,8 +71,6 @@ const char *uiInit(uiInitOptions *o)
 	if ((si.dwFlags & STARTF_USESHOWWINDOW) != 0)
 		nCmdShow = si.wShowWindow;
 
-	// LONGTERM set DPI awareness
-
 	hDefaultIcon = LoadIconW(NULL, IDI_APPLICATION);
 	if (hDefaultIcon == NULL)
 		return ieLastErr("loading default icon for window classes");

--- a/windows/init.cpp
+++ b/windows/init.cpp
@@ -65,6 +65,10 @@ const char *uiInit(uiInitOptions *o)
 	uiprivOptions = *o;
 
 	initAlloc();
+	
+	// works on Windows Vista and above
+	// do this before creating any windows
+	SetProcessDPIAware();
 
 	nCmdShow = SW_SHOWDEFAULT;
 	GetStartupInfoW(&si);

--- a/windows/libui.manifest
+++ b/windows/libui.manifest
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
 <assemblyIdentity
     version="1.0.0.0"
     processorArchitecture="*"
@@ -25,7 +25,17 @@
         <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
         <!--The ID below indicates application support for Windows 7 -->
         <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+        <!--The ID below indicates application support for Windows 10+ -->
+        <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
 </compatibility>
+<asmv3:application>
+    <asmv3:windowsSettings>
+        <!-- supported on Windows Vista and above -->
+        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+        <!-- supported on Windows 10 and above -->
+        <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+</asmv3:application>
 </assembly>
 

--- a/windows/multilineentry.cpp
+++ b/windows/multilineentry.cpp
@@ -45,9 +45,21 @@ static void uiMultilineEntryMinimumSize(uiWindowsControl *c, int *width, int *he
 	uiMultilineEntry *e = uiMultilineEntry(c);
 	uiWindowsSizing sizing;
 	int x, y;
+	int dpi;
 
+// GetDpiForWindow is available on Windows 10 1607 and beyond, which corresponds to this NTDDI_VERSION
+#if (NTDDI_VERSION >= 0x0A000002)
+	// the DPI of the monitor where this window is located
+	dpi = GetDpiForWindow(c->hwnd);
+	assert(dpi > 0);
+
+	// scale by the ratio of the window DPI to Windows' assumed DPI (96)
+	x = MulDiv(entryWidth, dpi, 96);
+	y = MulDiv(entryHeight, dpi, 96);
+#else
 	x = entryWidth;
 	y = entryHeight;
+#endif
 	uiWindowsGetSizing(e->hwnd, &sizing);
 	uiWindowsSizingDlgUnitsToPixels(&sizing, &x, &y);
 	*width = x;

--- a/windows/multilineentry.cpp
+++ b/windows/multilineentry.cpp
@@ -47,11 +47,11 @@ static void uiMultilineEntryMinimumSize(uiWindowsControl *c, int *width, int *he
 	int x, y;
 	int dpi;
 
-// GetDpiForWindow is available on Windows 10 1607 and beyond, which corresponds to this NTDDI_VERSION
-#if (NTDDI_VERSION >= 0x0A000002)
+#if (WINVER >= 0x0605)
 	// the DPI of the monitor where this window is located
-	dpi = GetDpiForWindow(c->hwnd);
-	assert(dpi > 0);
+	dpi = GetDpiForWindow(e->hwnd);
+	if (dpi <= 0)
+		logLastError(L"error getting monitor DPI");
 
 	// scale by the ratio of the window DPI to Windows' assumed DPI (96)
 	x = MulDiv(entryWidth, dpi, 96);


### PR DESCRIPTION
This adds two new keys, `dpiAware` and `dpiAwareness`, to all of the Windows application manifests. `dpiAware` was introduced in Windows Vista and `dpiAwareness` is the recommended key on Windows 10. Microsoft docs suggest they should both be included for compatibility.

I've enabled per-monitor awareness, a description of which is available [here](https://learn.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows?redirectedfrom=MSDN#per-monitor-and-per-monitor-v2-dpi-awareness).

I also included the `supportedOS` key for Windows 10 to all of the application manifests. This is not strictly necessary for DPI awareness; I can remove this change and reintroduce it another PR if that is preferred.

I tested this by running `tester.exe` on my laptop&mdash;which has a Hi DPI monitor&mdash;before and after the change. I noticed that the application appeared blurry before the change but is clearer now.

Let me know if you run into any issues.