### PR TITLE
Add table on row clicked and double clicked callbacks.

### DIFF
--- a/darwin/table.h
+++ b/darwin/table.h
@@ -18,6 +18,8 @@ struct uiTable {
 	uiTableModel *m;
 	void (*headerOnClicked)(uiTable *, int, void *);
 	void *headerOnClickedData;
+	void (*onRowDoubleClicked)(uiTable *, int, void *);
+	void *onRowDoubleClickedData;
 };
 
 // tablecolumn.m

--- a/darwin/table.h
+++ b/darwin/table.h
@@ -18,6 +18,8 @@ struct uiTable {
 	uiTableModel *m;
 	void (*headerOnClicked)(uiTable *, int, void *);
 	void *headerOnClickedData;
+	void (*onRowClicked)(uiTable *, int, void *);
+	void *onRowClickedData;
 	void (*onRowDoubleClicked)(uiTable *, int, void *);
 	void *onRowDoubleClickedData;
 };

--- a/darwin/table.m
+++ b/darwin/table.m
@@ -19,6 +19,7 @@
 - (id)initWithFrame:(NSRect)r uiprivT:(uiTable *)t uiprivM:(uiTableModel *)m;
 - (uiTable *)uiTable;
 - (void)restoreHeaderView;
+- (void)onClicked:(id)sender;
 - (void)onDoubleClicked:(id)sender;
 @end
 
@@ -43,6 +44,17 @@
 - (void)restoreHeaderView
 {
 	[self setHeaderView:self->headerViewRef];
+}
+
+- (void)onClicked:(id)sender
+{
+	uiTable *t = self->uiprivT;
+	NSInteger row = [self clickedRow];
+
+	if (row < 0)
+		return;
+
+	(*(t->onRowClicked))(t, row, t->onRowClickedData);
 }
 
 - (void)onDoubleClicked:(id)sender
@@ -226,9 +238,20 @@ static void defaultHeaderOnClicked(uiTable *table, int column, void *data)
 	// do nothing
 }
 
+static void defaultOnRowClicked(uiTable *table, int row, void *data)
+{
+	// do nothing
+}
+
 static void defaultOnRowDoubleClicked(uiTable *table, int row, void *data)
 {
 	// do nothing
+}
+
+void uiTableOnRowClicked(uiTable *t, void (*f)(uiTable *, int, void *), void *data)
+{
+	t->onRowClicked = f;
+	t->onRowClickedData = data;
 }
 
 void uiTableOnRowDoubleClicked(uiTable *t, void (*f)(uiTable *, int, void *), void *data)
@@ -265,7 +288,9 @@ uiTable *uiNewTable(uiTableParams *p)
 	[t->tv setAllowsTypeSelect:YES];
 	// TODO floatsGroupRows — do we even allow group rows?
 
+	uiTableOnRowClicked(t, defaultOnRowClicked, NULL);
 	uiTableOnRowDoubleClicked(t, defaultOnRowDoubleClicked, NULL);
+	[t->tv setAction: @selector(onClicked:)];
 	[t->tv setDoubleAction: @selector(onDoubleClicked:)];
 
 	memset(&sp, 0, sizeof (uiprivScrollViewCreateParams));

--- a/darwin/table.m
+++ b/darwin/table.m
@@ -19,6 +19,7 @@
 - (id)initWithFrame:(NSRect)r uiprivT:(uiTable *)t uiprivM:(uiTableModel *)m;
 - (uiTable *)uiTable;
 - (void)restoreHeaderView;
+- (void)onDoubleClicked:(id)sender;
 @end
 
 @implementation uiprivTableView
@@ -42,6 +43,17 @@
 - (void)restoreHeaderView
 {
 	[self setHeaderView:self->headerViewRef];
+}
+
+- (void)onDoubleClicked:(id)sender
+{
+	uiTable *t = self->uiprivT;
+	NSInteger row = [self clickedRow];
+
+	if (row < 0)
+		return;
+
+	(*(t->onRowDoubleClicked))(t, row, t->onRowDoubleClickedData);
 }
 
 // TODO is this correct for overflow scrolling?
@@ -214,6 +226,17 @@ static void defaultHeaderOnClicked(uiTable *table, int column, void *data)
 	// do nothing
 }
 
+static void defaultOnRowDoubleClicked(uiTable *table, int row, void *data)
+{
+	// do nothing
+}
+
+void uiTableOnRowDoubleClicked(uiTable *t, void (*f)(uiTable *, int, void *), void *data)
+{
+	t->onRowDoubleClicked = f;
+	t->onRowDoubleClickedData = data;
+}
+
 uiTable *uiNewTable(uiTableParams *p)
 {
 	uiTable *t;
@@ -241,6 +264,9 @@ uiTable *uiNewTable(uiTableParams *p)
 	[t->tv setGridStyleMask:NSTableViewGridNone];
 	[t->tv setAllowsTypeSelect:YES];
 	// TODO floatsGroupRows — do we even allow group rows?
+
+	uiTableOnRowDoubleClicked(t, defaultOnRowDoubleClicked, NULL);
+	[t->tv setDoubleAction: @selector(onDoubleClicked:)];
 
 	memset(&sp, 0, sizeof (uiprivScrollViewCreateParams));
 	sp.DocumentView = t->tv;

--- a/test/page16.c
+++ b/test/page16.c
@@ -94,8 +94,10 @@ static void modelSetCellValue(uiTableModelHandler *mh, uiTableModel *m, int row,
 			uiTableModelRowChanged(m, prevYellowRow);
 		uiTableModelRowChanged(m, yellowRow);
 	}
-	if (col == 7)
+	if (col == 7) {
 		checkStates[row] = uiTableValueInt(val);
+		printf("Checkbox[%d] = %d\n", row, checkStates[row]);
+	}
 }
 
 void headerVisibleToggled(uiCheckbox *c, void *data)
@@ -119,11 +121,23 @@ static void changedColumnWidth(uiSpinbox *s, void *data)
 	uiTableColumnSetWidth(t, uiSpinboxValue(columnID), uiSpinboxValue(columnWidth));
 }
 
+
+uiLabel *lblRowClicked;
+static void onRowClicked(uiTable *table, int row, void *data)
+{
+	char str[128];
+
+	printf("Clicked row %d\n", row);
+	sprintf(str, "Clicked row %d", row);
+	uiLabelSetText(lblRowClicked, str);
+}
+
 uiLabel *lblRowDoubleClicked;
 static void onRowDoubleClicked(uiTable *table, int row, void *data)
 {
 	char str[128];
 
+	printf("Double clicked row %d\n", row);
 	sprintf(str, "Double clicked row %d", row);
 	uiLabelSetText(lblRowDoubleClicked, str);
 }
@@ -226,9 +240,13 @@ uiBox *makePage16(void)
 	uiBoxSetPadded(stats, 1);
 	uiBoxAppend(page16, uiControl(stats), 0);
 
+	lblRowClicked = uiNewLabel("Clicked row -");
+	uiBoxAppend(stats, uiControl(lblRowClicked), 0);
+
 	lblRowDoubleClicked = uiNewLabel("Double clicked row -");
 	uiBoxAppend(stats, uiControl(lblRowDoubleClicked), 0);
 
+	uiTableOnRowClicked(t, onRowClicked, NULL);
 	uiTableOnRowDoubleClicked(t, onRowDoubleClicked, NULL);
 
 	return page16;

--- a/test/page16.c
+++ b/test/page16.c
@@ -119,6 +119,15 @@ static void changedColumnWidth(uiSpinbox *s, void *data)
 	uiTableColumnSetWidth(t, uiSpinboxValue(columnID), uiSpinboxValue(columnWidth));
 }
 
+uiLabel *lblRowDoubleClicked;
+static void onRowDoubleClicked(uiTable *table, int row, void *data)
+{
+	char str[128];
+
+	sprintf(str, "Double clicked row %d", row);
+	uiLabelSetText(lblRowDoubleClicked, str);
+}
+
 static uiTableModel *m;
 
 static void headerOnClicked(uiTable *t, int col, void *data)
@@ -140,6 +149,7 @@ uiBox *makePage16(void)
 {
 	uiBox *page16;
 	uiBox *controls;
+	uiBox *stats;
 	uiCheckbox *headerVisible;
 	uiTable *t;
 	uiTableParams p;
@@ -211,6 +221,15 @@ uiBox *makePage16(void)
 
 	uiSpinboxOnChanged(columnID, changedColumnID, t);
 	uiSpinboxOnChanged(columnWidth, changedColumnWidth, t);
+
+	stats = newHorizontalBox();
+	uiBoxSetPadded(stats, 1);
+	uiBoxAppend(page16, uiControl(stats), 0);
+
+	lblRowDoubleClicked = uiNewLabel("Double clicked row -");
+	uiBoxAppend(stats, uiControl(lblRowDoubleClicked), 0);
+
+	uiTableOnRowDoubleClicked(t, onRowDoubleClicked, NULL);
 
 	return page16;
 }

--- a/ui.h
+++ b/ui.h
@@ -3734,12 +3734,29 @@ _UI_EXTERN uiTable *uiNewTable(uiTableParams *params);
 
 
 /**
- * Registers a callback for when the user double clicks a table row.
+ * Registers a callback for when the user single clicks a table row.
  *
  * @param t uiTable instance.
  * @param f Callback function.\n
  *          @p sender Back reference to the instance that triggered the callback.\n
  *          @p row Row index that was clicked.\n
+ *          @p senderData User data registered with the sender instance.
+ * @param data User data to be passed to the callback.
+ *
+ * @note Only one callback can be registered at a time.
+ * @memberof uiTable
+ */
+_UI_EXTERN void uiTableOnRowClicked(uiTable *t,
+	void (*f)(uiTable *t, int row, void *data),
+	void *data);
+
+/**
+ * Registers a callback for when the user double clicks a table row.
+ *
+ * @param t uiTable instance.
+ * @param f Callback function.\n
+ *          @p sender Back reference to the instance that triggered the callback.\n
+ *          @p row Row index that was double clicked.\n
  *          @p senderData User data registered with the sender instance.
  * @param data User data to be passed to the callback.
  *

--- a/ui.h
+++ b/ui.h
@@ -3760,6 +3760,9 @@ _UI_EXTERN void uiTableOnRowClicked(uiTable *t,
  *          @p senderData User data registered with the sender instance.
  * @param data User data to be passed to the callback.
  *
+ * @note The double click callback is always preceded by one uiTableOnRowClicked() callback.
+ * @bug For unix systems linking against `GTK < 3.14` the preceding uiTableOnRowClicked()
+ *      callback will be triggered twice.
  * @note Only one callback can be registered at a time.
  * @memberof uiTable
  */

--- a/ui.h
+++ b/ui.h
@@ -3732,6 +3732,24 @@ _UI_EXTERN void uiTableHeaderSetVisible(uiTable *t, int visible);
  */
 _UI_EXTERN uiTable *uiNewTable(uiTableParams *params);
 
+
+/**
+ * Registers a callback for when the user double clicks a table row.
+ *
+ * @param t uiTable instance.
+ * @param f Callback function.\n
+ *          @p sender Back reference to the instance that triggered the callback.\n
+ *          @p row Row index that was clicked.\n
+ *          @p senderData User data registered with the sender instance.
+ * @param data User data to be passed to the callback.
+ *
+ * @note Only one callback can be registered at a time.
+ * @memberof uiTable
+ */
+_UI_EXTERN void uiTableOnRowDoubleClicked(uiTable *t,
+	void (*f)(uiTable *t, int row, void *data),
+	void *data);
+
 /**
  * Sets the column's sort indicator displayed in the table header.
  *

--- a/unix/table.c
+++ b/unix/table.c
@@ -589,6 +589,27 @@ void uiTableOnRowDoubleClicked(uiTable *t, void (*f)(uiTable *, int, void *), vo
 	t->onRowDoubleClickedData = data;
 }
 
+#if GTK_CHECK_VERSION(3, 14, 0)
+static void onButtonPressed(GtkGestureMultiPress *gesture, gint nPress, gdouble wx, gdouble wy, gpointer data)
+{
+	uiTable *t = uiTable(data);
+	GtkTreePath *path;
+	gint row, x, y;
+
+	gtk_tree_view_convert_widget_to_bin_window_coords(t->tv, wx, wy, &x, &y);
+	gtk_tree_view_get_path_at_pos(GTK_TREE_VIEW(t->tv), x, y, &path, NULL, NULL, NULL);
+	if (path == NULL)
+		return;
+
+	row = gtk_tree_path_get_indices(path)[0];
+	gtk_tree_path_free(path);
+
+	if (nPress == 1)
+		(*(t->onRowClicked))(t, row, t->onRowClickedData);
+	else if (nPress == 2)
+		(*(t->onRowDoubleClicked))(t, row, t->onRowDoubleClickedData);
+}
+#else
 static gboolean onButtonPressed(GtkWidget *tv, GdkEventButton *event, gpointer data)
 {
 	uiTable *t = uiTable(data);
@@ -607,17 +628,21 @@ static gboolean onButtonPressed(GtkWidget *tv, GdkEventButton *event, gpointer d
 	row = gtk_tree_path_get_indices(path)[0];
 	gtk_tree_path_free(path);
 
-	if(event->type == GDK_BUTTON_PRESS)
+	if (event->type == GDK_BUTTON_PRESS)
 		(*(t->onRowClicked))(t, row, t->onRowClickedData);
-	else if(event->type == GDK_2BUTTON_PRESS)
+	else if (event->type == GDK_2BUTTON_PRESS)
 		(*(t->onRowDoubleClicked))(t, row, t->onRowDoubleClickedData);
 
 	return FALSE;
 }
+#endif
 
 uiTable *uiNewTable(uiTableParams *p)
 {
 	uiTable *t;
+#if GTK_CHECK_VERSION(3, 14, 0)
+	GtkGesture *gesture;
+#endif
 
 	uiUnixNewControl(uiTable, t);
 
@@ -636,7 +661,14 @@ uiTable *uiNewTable(uiTableParams *p)
 	// TODO set up t->tv
 	uiTableOnRowClicked(t, defaultOnRowClicked, NULL);
 	uiTableOnRowDoubleClicked(t, defaultOnRowDoubleClicked, NULL);
+
+#if GTK_CHECK_VERSION(3, 14, 0)
+	gesture = gtk_gesture_multi_press_new(GTK_WIDGET(t->tv));
+	g_signal_connect(gesture, "pressed", G_CALLBACK(onButtonPressed), t);
+	g_object_set_data_full(G_OBJECT(t->tv), "table-pressed-gesture", gesture, g_object_unref);
+#else
 	g_signal_connect(t->tv, "button-press-event", G_CALLBACK(onButtonPressed), t);
+#endif
 
 	gtk_container_add(t->scontainer, t->treeWidget);
 	// and make the tree view visible; only the scrolled window's visibility is controlled by libui

--- a/unix/table.c
+++ b/unix/table.c
@@ -20,6 +20,8 @@ struct uiTable {
 	guint indeterminateTimer;
 	void (*headerOnClicked)(uiTable *, int, void *);
 	void *headerOnClickedData;
+	void (*onRowDoubleClicked)(uiTable *, int, void *);
+	void *onRowDoubleClickedData;
 };
 
 /*
@@ -563,6 +565,25 @@ static void uiTableDestroy(uiControl *c)
 	uiFreeControl(uiControl(t));
 }
 
+static void onRowDoubleClicked(GtkTreeView *tv, GtkTreePath *path, GtkTreeViewColumn *col, gpointer data)
+{
+	uiTable *t = uiTable(data);
+	gint row = gtk_tree_path_get_indices(path)[0];
+
+	(*(t->onRowDoubleClicked))(t, row, t->onRowDoubleClickedData);
+}
+
+static void defaultOnRowDoubleClicked(uiTable *table, int row, void *data)
+{
+	// do nothing
+}
+
+void uiTableOnRowDoubleClicked(uiTable *t, void (*f)(uiTable *, int, void *), void *data)
+{
+	t->onRowDoubleClicked = f;
+	t->onRowDoubleClickedData = data;
+}
+
 uiTable *uiNewTable(uiTableParams *p)
 {
 	uiTable *t;
@@ -580,7 +601,10 @@ uiTable *uiNewTable(uiTableParams *p)
 
 	t->treeWidget = gtk_tree_view_new_with_model(GTK_TREE_MODEL(t->model));
 	t->tv = GTK_TREE_VIEW(t->treeWidget);
+
 	// TODO set up t->tv
+	uiTableOnRowDoubleClicked(t, defaultOnRowDoubleClicked, NULL);
+	g_signal_connect(t->tv, "row-activated", G_CALLBACK(onRowDoubleClicked), t);
 
 	gtk_container_add(t->scontainer, t->treeWidget);
 	// and make the tree view visible; only the scrolled window's visibility is controlled by libui

--- a/windows/table.cpp
+++ b/windows/table.cpp
@@ -59,6 +59,17 @@ void uiTableModelRowDeleted(uiTableModel *m, int oldIndex)
 	}
 }
 
+static void defaultOnRowDoubleClicked(uiTable *table, int row, void *data)
+{
+	// do nothing
+}
+
+void uiTableOnRowDoubleClicked(uiTable *t, void (*f)(uiTable *, int, void *), void *data)
+{
+	t->onRowDoubleClicked = f;
+	t->onRowDoubleClickedData = data;
+}
+
 uiTableModelHandler *uiprivTableModelHandler(uiTableModel *m)
 {
 	return m->mh;
@@ -311,6 +322,15 @@ static BOOL onWM_NOTIFY(uiControl *c, HWND hwnd, NMHDR *nmhdr, LRESULT *lResult)
 		}
 		return TRUE;
 #endif
+	case NM_DBLCLK:
+		{
+			LVHITTESTINFO ht = {};
+			ht.pt = ((NMITEMACTIVATE *)nmhdr)->ptAction;
+			if (SendMessageW(t->hwnd, LVM_SUBITEMHITTEST, 0, (LPARAM) &ht) == -1)
+				return FALSE;
+			(*(t->onRowDoubleClicked))(t, ht.iItem, t->onRowDoubleClickedData);
+			return TRUE;
+		}
 	case LVN_ITEMCHANGED:
 		{
 			NMLISTVIEW *nm = (NMLISTVIEW *) nmhdr;
@@ -582,6 +602,8 @@ uiTable *uiNewTable(uiTableParams *p)
 	t->indeterminatePositions = new std::map<std::pair<int, int>, LONG>;
 	if (SetWindowSubclass(t->hwnd, tableSubProc, 0, (DWORD_PTR) t) == FALSE)
 		logLastError(L"SetWindowSubclass()");
+
+	uiTableOnRowDoubleClicked(t, defaultOnRowDoubleClicked, NULL);
 
 	return t;
 }

--- a/windows/table.cpp
+++ b/windows/table.cpp
@@ -59,9 +59,20 @@ void uiTableModelRowDeleted(uiTableModel *m, int oldIndex)
 	}
 }
 
+static void defaultOnRowClicked(uiTable *table, int row, void *data)
+{
+	// do nothing
+}
+
 static void defaultOnRowDoubleClicked(uiTable *table, int row, void *data)
 {
 	// do nothing
+}
+
+void uiTableOnRowClicked(uiTable *t, void (*f)(uiTable *, int, void *), void *data)
+{
+	t->onRowClicked = f;
+	t->onRowClickedData = data;
 }
 
 void uiTableOnRowDoubleClicked(uiTable *t, void (*f)(uiTable *, int, void *), void *data)
@@ -315,12 +326,21 @@ static BOOL onWM_NOTIFY(uiControl *c, HWND hwnd, NMHDR *nmhdr, LRESULT *lResult)
 		*lResult = 0;
 		return TRUE;
 #else
-		hr = uiprivTableHandleNM_CLICK(t, (NMITEMACTIVATE *) nmhdr, lResult);
-		if (hr != S_OK) {
-			// TODO
-			return FALSE;
+		{
+			LVHITTESTINFO ht = {};
+			ht.pt = ((NMITEMACTIVATE *)nmhdr)->ptAction;
+			if (SendMessageW(t->hwnd, LVM_SUBITEMHITTEST, 0, (LPARAM) &ht) == -1)
+				return FALSE;
+			(*(t->onRowClicked))(t, ht.iItem, t->onRowClickedData);
+
+			// Handle editing
+			hr = uiprivTableHandleNM_CLICK(t, (NMITEMACTIVATE *) nmhdr, lResult);
+			if (hr != S_OK) {
+				// TODO
+				return FALSE;
+			}
+			return TRUE;
 		}
-		return TRUE;
 #endif
 	case NM_DBLCLK:
 		{
@@ -603,6 +623,7 @@ uiTable *uiNewTable(uiTableParams *p)
 	if (SetWindowSubclass(t->hwnd, tableSubProc, 0, (DWORD_PTR) t) == FALSE)
 		logLastError(L"SetWindowSubclass()");
 
+	uiTableOnRowClicked(t, defaultOnRowClicked, NULL);
 	uiTableOnRowDoubleClicked(t, defaultOnRowDoubleClicked, NULL);
 
 	return t;

--- a/windows/table.hpp
+++ b/windows/table.hpp
@@ -44,6 +44,8 @@ struct uiTable {
 	int editedSubitem;
 	void (*headerOnClicked)(uiTable *, int, void *);
 	void *headerOnClickedData;
+	void (*onRowClicked)(uiTable *, int, void *);
+	void *onRowClickedData;
 	void (*onRowDoubleClicked)(uiTable *, int, void *);
 	void *onRowDoubleClickedData;
 };

--- a/windows/table.hpp
+++ b/windows/table.hpp
@@ -44,6 +44,8 @@ struct uiTable {
 	int editedSubitem;
 	void (*headerOnClicked)(uiTable *, int, void *);
 	void *headerOnClickedData;
+	void (*onRowDoubleClicked)(uiTable *, int, void *);
+	void *onRowDoubleClickedData;
 };
 extern int uiprivTableProgress(uiTable *t, int item, int subitem, int modelColumn, LONG *pos);
 


### PR DESCRIPTION
Proposal to add two new API functions to set a callback for when a user clicks and double clicks a table row.

```c
void uiTableOnRowClicked(uiTable *t, void (*f)(uiTable *t, int row, void *data), void *data);
void uiTableOnRowDoubleClicked(uiTable *t, void (*f)(uiTable *t, int row, void *data), void *data);
```

Implementations provided for darwin, unix, and windows. A small sample usage is provided on page16.

Two platform inconsistencies I found while testing:

1. Unix will send two `uiTableOnRowClicked` events when double clicking before the `uiTableOnRowDoubleClicked` event. Windows and Mac will only send one.
2. Mac will not select a row when ticking a checkbox, hence no `uiTableOnRowClicked` is sent. Unix and Windows select the row (first), send a `uiTableOnRowClicked` event and then send a uiTableValueChanged event.

My suggestions:

1. Can be ignored for now, as this will be automatically fixed once we switch to `GtkGesture` based events `Gtk >= 3.14` or at the latest Gtk4. A working fix that requires `Gtk >= 3.14` can be found [here](https://github.com/szanni/libui-ng/tree/table-on-row-clicked-and-double-clicked-gtk3-14).
2. Not sure what to do about the differing behavior for mac in general, this should possibly be raised as an issue on its own? Comments welcome.

This would supersede #44, adding a differentiation between single and double click and fixing all problems related to keyboard events on the unix side as well (by not implicitly adding any handlers).
Supersedes old PR [libui#516](https://github.com/andlabs/libui/pull/516)
