### PR TITLE
ci: Add libtype shared to meson-windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         # windows-latest, windows-2022
         os: [windows-latest]
         arch: [x86, x64]
-        libtype: [static] # FIXME [static, shared]
+        libtype: [static, shared]
         # debug, debugoptimized, release
         buildtype: [debug]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Hello. @cody271 @szanni and everyone.

I have a question and a pull request.

I would like to create a Ruby package containing a pre-release version of libui-ng.
But for now, I am attaching a Rake (Rake is the Ruby equivalent of Make) script that can download a build of libui-ng from the nightly.link you gave us so that people who want to use libui-ng can easily try it out.

However, on Windows, there is no shared library because shared is not enabled in the build.yml. Browsing through the blame, I noticed that @cody271 has intentionally disabled shared in the past.  (https://github.com/libui-ng/libui-ng/commit/9210b9f88ac524e3b5b2f55d8504827a13c3a2b9)

To see if it works, I ran ci with `shared` enabled in the forked repository of libui-ng. Then libui.dll was generated. 

https://github.com/kojix2/libui-ng/actions/runs/3258763203

The attached test file worked and I was able to call libui.dll from Ruby's LibUI. Of course I didn't look at all of them, and there may be something wrong with them, but at first glance they appear to be working.

So my question is: What is the reason that this option is disabled? 

Would you consider enabling this option if possible?