### PR TITLE
ci: Update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Run Tests
       run: xvfb-run meson test -C builddir --verbose
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: Ubuntu-${{ matrix.arch }}-${{ matrix.libtype }}-${{ matrix.buildtype }}
         # lib + header + examples + test + build-log
@@ -83,7 +83,7 @@ jobs:
       - name: Run Tests
         run: meson test -C builddir --verbose
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Win-${{ matrix.arch }}-${{ matrix.libtype }}-${{ matrix.buildtype }}
           # lib + header + examples + test + build-log
@@ -130,7 +130,7 @@ jobs:
       - name: Run Tests
         run: meson test -C builddir --verbose
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Mingw-${{ matrix.arch }}-static-${{ matrix.buildtype }}
           # lib + header + examples + test + build-log
@@ -166,7 +166,7 @@ jobs:
       - name: Run Tests
         run: meson test -C builddir --verbose
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: macOS-x64-${{ matrix.libtype }}-${{ matrix.buildtype }}
           # lib + header + examples + test + build-log

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install -y libgtk-3-dev xvfb
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Meson Setup Build
       run: meson setup builddir --buildtype=${{ matrix.buildtype }} --default-library=${{ matrix.libtype }}
     - name: Ninja Build
@@ -62,7 +62,7 @@ jobs:
     name: Win-${{ matrix.arch }}-${{ matrix.libtype }}
     steps:
       # Setup build env
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
@@ -122,7 +122,7 @@ jobs:
           pacboy: >-
             toolchain:x
             meson:x
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Meson Setup Build
         run: meson setup builddir --buildtype=${{ matrix.buildtype }} --default-library=static
       - name: Ninja Build
@@ -158,7 +158,7 @@ jobs:
           brew update
           brew install meson ninja
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Meson Setup Build
         run: meson setup builddir --buildtype=${{ matrix.buildtype }} --default-library=${{ matrix.libtype }}
       - name: Ninja Build


### PR DESCRIPTION
During #149, I see small warning messages.

![image](https://user-images.githubusercontent.com/5798442/196028827-1e996cb1-bf2a-43a9-90c5-2e55cedc0dec.png)

>Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/upload-artifact, actions/checkout

This pull request will upgrade some ACTIONS.
Thank you.