### PR TITLE
New examples (reworked)

### DIFF
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <ui.h>
+
+int onClosing(uiWindow *w, void *data)
+{
+	uiQuit();
+	return 1;
+}
+
+int main(void)
+{
+	uiInitOptions o = {0};
+	const char *err;
+	uiWindow *w;
+	uiLabel *l;
+
+	err = uiInit(&o);
+	if (err != NULL) {
+		fprintf(stderr, "Error initializing libui-ng: %s\n", err);
+		uiFreeInitError(err);
+		return 1;
+	}
+
+	// Create a new window
+	w = uiNewWindow("Hello World!", 300, 30, 0);
+	uiWindowOnClosing(w, onClosing, NULL);
+
+	l = uiNewLabel("Hello, World!");
+	uiWindowSetChild(w, uiControl(l));
+
+	uiControlShow(uiControl(w));
+	uiMain();
+	uiUninit();
+	return 0;
+}
+

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -48,6 +48,12 @@ libui_examples = {
 	'datetime': {
 		'sources':		['datetime/main.c'],
 	},
+	'hello-world': {
+		'sources':		['hello-world/main.c'],
+	},
+	'window': {
+		'sources':		['window/main.c'],
+	},
 }
 foreach name, args : libui_examples
 	# TODO once we upgrade to 0.49.0, add pie: true

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -56,6 +56,7 @@ foreach name, args : libui_examples
 		link_with: libui_libui,
 		cpp_args: args.get('cpp_args', []),
 		link_args: args.get('link_args', []) + libui_example_link_args,
+		include_directories: include_directories('..'),
 		gui_app: false,
 		install: false)
 endforeach

--- a/examples/window/main.c
+++ b/examples/window/main.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+#include <ui.h>
+
+int onClosing(uiWindow *w, void *data)
+{
+	uiQuit();
+	return 1;
+}
+
+int main(void)
+{
+	uiInitOptions o = {0};
+	const char *err;
+	uiWindow *w;
+
+	err = uiInit(&o);
+	if (err != NULL) {
+		fprintf(stderr, "Error initializing libui-ng: %s\n", err);
+		uiFreeInitError(err);
+		return 1;
+	}
+
+	// Create a new window
+	w = uiNewWindow("Window Title", 300, 30, 0);
+
+	uiWindowOnClosing(w, onClosing, NULL);
+	uiControlShow(uiControl(w));
+	uiMain();
+	uiUninit();
+	return 0;
+}
+


### PR DESCRIPTION
Essentially just #34 cleaned up to my liking to get things moving. Not sure if there is a better way to do this on Github.

- `hello-world` creates a window with `Hello World!` in the title (if visible) and a label containing `Hello World!`
- `window` creates an empty window

I also took the liberty of adding the top level directory to the include path so we can use `#include <ui.h>`  for the examples. Updating the other examples is TBD, but I would like to check them more thoroughly in general. The include path supersedes the system `/usr/include` at least on my system.