### PR TITLE
darwin: Remove uiWindow singleton delegate by subclassing.

### DIFF
--- a/darwin/uipriv_darwin.h
+++ b/darwin/uipriv_darwin.h
@@ -77,7 +77,16 @@ extern void uiprivFinishNewTextField(NSTextField *, BOOL);
 extern NSTextField *uiprivNewEditableTextField(void);
 
 // window.m
-@interface uiprivNSWindow : NSWindow
+@interface uiprivNSWindow : NSWindow<NSWindowDelegate> {
+	uiWindow *window;
+}
+- (BOOL)windowShouldClose:(id)sender;
+- (void)windowDidResize:(NSNotification *)note;
+- (void)windowDidEnterFullScreen:(NSNotification *)note;
+- (void)windowDidExitFullScreen:(NSNotification *)note;
+- (void)windowDidBecomeKey:(NSNotification *)note;
+- (void)windowDidResignKey:(NSNotification *)note;
+- (uiWindow *)window;
 - (void)uiprivDoMove:(NSEvent *)initialEvent;
 - (void)uiprivDoResize:(NSEvent *)initialEvent on:(uiWindowResizeEdge)edge;
 @end


### PR DESCRIPTION
- Removes global state and related problems

Related to #157 and #160

I hope I did not break any of the callback code or menu shenanigans. I tested some of it in the tester, but since we don't have an established protocol yet, it's hard to tell.

@e1732a364fed does that fix window creation in the golang bindings for you with this patch? Not sure if you can test.