### PR TITLE
doc: Add a comment that `window` may be `NULL`.

### DIFF
--- a/ui.h
+++ b/ui.h
@@ -1729,11 +1729,14 @@ _UI_EXTERN void uiMenuItemDisable(uiMenuItem *m);
  * @param m uiMenuItem instance.
  * @param f Callback function.\n
  *          @p sender Back reference to the instance that triggered the callback.\n
- *          @p window Reference to the window from which the callback got triggered.\
+ *          @p window Reference to the window from which the callback got triggered
+ *                    or `NULL` under rare circumstances.\n
  *          @p senderData User data registered with the sender instance.
  * @param data User data to be passed to the callback.
  *
  * @note Only one callback can be registered at a time.
+ * @todo Find a way of triggering `window` being `NULL` on darwin or remove the
+ *       comment and code.
  * @memberof uiMenuItem
  */
 _UI_EXTERN void uiMenuItemOnClicked(uiMenuItem *m,


### PR DESCRIPTION
Apparently uiMenuItemOnClicked() may pass `NULL` as the `window` parameter under certain circumstances on darwin. At least that possibility is suggested here:
- darwin/window.m:461
- darwin/window.m:142

I added a @todo to the docs as well, as I am unaware of how to trigger such behavior. The code does handle that possibility though, so users need to be aware of the possibility to not trigger any `NULL` pointer derefs.