### PR TITLE
unit: Add unit tests for uiMenu

### DIFF
--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -2,22 +2,11 @@
 
 #include "unit.h"
 
-#define UNIT_TEST_WIDTH 300
-#define UNIT_TEST_HEIGHT 200
-
-static int onClosing(uiWindow *w, void *data)
+int unitWindowOnClosingQuit(uiWindow *w, void *data)
 {
 	uiQuit();
 	return 1;
 }
-
-/*
-int close(void *data)
-{
-	uiQuit();
-	return 1;
-}
-*/
 
 int unitTestsSetup(void **state)
 {
@@ -38,8 +27,8 @@ int unitTestSetup(void **_state)
 	uiInitOptions o = {0};
 
 	assert_null(uiInit(&o));
-	state->w = uiNewWindow("Unit Test", UNIT_TEST_WIDTH, UNIT_TEST_HEIGHT, 0);
-	uiWindowOnClosing(state->w, onClosing, NULL);
+	state->w = uiNewWindow("Unit Test", UNIT_TEST_WINDOW_WIDTH, UNIT_TEST_WINDOW_HEIGHT, 0);
+	uiWindowOnClosing(state->w, unitWindowOnClosingQuit, NULL);
 	return 0;
 }
 

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -57,6 +57,7 @@ int main(void)
 	int failedComponents = 0;
 	struct unitTest unitTests[] = {
 		{ initRunUnitTests },
+		{ menuRunUnitTests },
 		{ sliderRunUnitTests },
 		{ spinboxRunUnitTests },
 		{ labelRunUnitTests },

--- a/test/unit/menu.c
+++ b/test/unit/menu.c
@@ -1,0 +1,143 @@
+#include "unit.h"
+
+int menuTestSetup(void **state);
+int menuTestTeardown(void **state);
+
+static void menuNew(void **state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+}
+
+static void menuNewInitTwice(void **state)
+{
+	uiMenu *m;
+
+	menuTestSetup(state);
+	m = uiNewMenu("Menu 1");
+	menuTestTeardown(state);
+
+	menuTestSetup(state);
+	m = uiNewMenu("Menu 2");
+	menuTestTeardown(state);
+}
+
+static void menuNewEmptyString(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("");
+}
+
+static void menuAppendItem(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendItem(m, "Item");
+}
+
+static void menuAppendItems(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendItem(m, "Item 1");
+	uiMenuAppendItem(m, "Item 2");
+}
+
+static void menuAppendCheckItem(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendCheckItem(m, "Item");
+}
+
+static void menuAppendCheckItems(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendCheckItem(m, "Item 1");
+	uiMenuAppendCheckItem(m, "Item 2");
+}
+
+static void menuAppendAboutItem(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendAboutItem(m);
+}
+
+static void menuAppendPreferencesItem(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendPreferencesItem(m);
+}
+
+static void menuAppendQuitItem(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendQuitItem(m);
+}
+
+static void menuAppendSeparator(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendSeparator(m);
+}
+
+int menuTestSetup(void **_state)
+{
+	uiInitOptions o = {0};
+
+	assert_null(uiInit(&o));
+	return 0;
+}
+
+int menuTestTeardown(void **_state)
+{
+	struct state *state = *_state;
+
+	state->w = uiNewWindow("Menu Test", UNIT_TEST_WINDOW_WIDTH, UNIT_TEST_WINDOW_HEIGHT, 1);
+	uiWindowOnClosing(state->w, unitWindowOnClosingQuit, NULL);
+
+	uiControlShow(uiControl(state->w));
+	uiMainSteps();
+	uiMainStep(1);
+	uiControlDestroy(uiControl(state->w));
+	uiUninit();
+	return 0;
+}
+
+#define menuUnitTest(f) cmocka_unit_test_setup_teardown((f), \
+		menuTestSetup, menuTestTeardown)
+
+int menuRunUnitTests(void)
+{
+	const struct CMUnitTest tests[] = {
+		menuUnitTest(menuNew),
+		cmocka_unit_test(menuNewInitTwice),
+		menuUnitTest(menuNewEmptyString),
+		menuUnitTest(menuAppendItem),
+		menuUnitTest(menuAppendItems),
+		menuUnitTest(menuAppendCheckItem),
+		menuUnitTest(menuAppendCheckItems),
+		menuUnitTest(menuAppendAboutItem),
+		menuUnitTest(menuAppendPreferencesItem),
+		menuUnitTest(menuAppendQuitItem),
+		menuUnitTest(menuAppendSeparator),
+	};
+
+	return cmocka_run_group_tests_name("uiMenu", tests, unitTestsSetup, unitTestsTeardown);
+}
+

--- a/test/unit/menu.c
+++ b/test/unit/menu.c
@@ -96,6 +96,79 @@ static void menuAppendSeparator(void **_state)
 	uiMenuAppendSeparator(m);
 }
 
+static void menuAppendFull(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendItem(m, "Item");
+	uiMenuAppendSeparator(m);
+	uiMenuAppendCheckItem(m, "Check Item");
+	uiMenuAppendAboutItem(m);
+	uiMenuAppendPreferencesItem(m);
+	uiMenuAppendQuitItem(m);
+}
+
+static void menuItemEnable(void **_state)
+{
+	uiMenu *m;
+	uiMenuItem *i;
+
+	m = uiNewMenu("Menu");
+	i = uiMenuAppendItem(m, "Item");
+	uiMenuItemEnable(i);
+}
+
+static void menuItemDisable(void **_state)
+{
+	uiMenu *m;
+	uiMenuItem *i;
+
+	m = uiNewMenu("Menu");
+	i = uiMenuAppendItem(m, "Item");
+	uiMenuItemDisable(i);
+}
+
+static void menuItemCheckedDefaultFalse(void **_state)
+{
+	uiMenu *m;
+	uiMenuItem *i;
+
+	m = uiNewMenu("Menu");
+	i = uiMenuAppendCheckItem(m, "Item");
+	assert_int_equal(uiMenuItemChecked(i), 0);
+}
+
+static void menuItemSetChecked(void **_state)
+{
+	uiMenu *m;
+	uiMenuItem *i;
+
+	m = uiNewMenu("Menu");
+	i = uiMenuAppendCheckItem(m, "Item");
+	uiMenuItemSetChecked(i, 1);
+	assert_int_equal(uiMenuItemChecked(i), 1);
+	uiMenuItemSetChecked(i, 0);
+	assert_int_equal(uiMenuItemChecked(i), 0);
+}
+
+static void onClickedNoCall(uiMenuItem *i, uiWindow *w, void *data)
+{
+	function_called();
+}
+
+static void menuItemOnClicked(void **_state)
+{
+	uiMenu *m;
+	uiMenuItem *i;
+
+	m = uiNewMenu("Menu");
+	i = uiMenuAppendItem(m, "Item");
+	// FIXME: https://gitlab.com/cmocka/cmocka/-/issues/18
+	//expect_function_calls(onClickedNoCall, 0);
+	uiMenuItemOnClicked(i, onClickedNoCall, NULL);
+}
+
 int menuTestSetup(void **_state)
 {
 	uiInitOptions o = {0};
@@ -136,6 +209,12 @@ int menuRunUnitTests(void)
 		menuUnitTest(menuAppendPreferencesItem),
 		menuUnitTest(menuAppendQuitItem),
 		menuUnitTest(menuAppendSeparator),
+		menuUnitTest(menuAppendFull),
+		menuUnitTest(menuItemEnable),
+		menuUnitTest(menuItemDisable),
+		menuUnitTest(menuItemCheckedDefaultFalse),
+		menuUnitTest(menuItemSetChecked),
+		menuUnitTest(menuItemOnClicked),
 	};
 
 	return cmocka_run_group_tests_name("uiMenu", tests, unitTestsSetup, unitTestsTeardown);

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -11,6 +11,7 @@ libui_unit_sources = [
         'combobox.c',
         'checkbox.c',
         'radiobuttons.c',
+        'menu.c',
 ]
 
 if libui_OS == 'windows'

--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -30,6 +30,11 @@ struct state {
 	uiControl *c;
 };
 
+int unitWindowOnClosingQuit(uiWindow *w, void *data);
+
+#define UNIT_TEST_WINDOW_WIDTH 300
+#define UNIT_TEST_WINDOW_HEIGHT 200
+
 /**
  * Helper for setting up the state variable used in unit tests.
  */

--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -21,6 +21,7 @@ int buttonRunUnitTests(void);
 int comboboxRunUnitTests(void);
 int checkboxRunUnitTests(void);
 int radioButtonsRunUnitTests(void);
+int menuRunUnitTests(void);
 
 /**
  * Helper for general setup/teardown of controls embedded in a window.


### PR DESCRIPTION
Edit: I must have pressed the wrong PR button. I would still like to add more tests to this. But here you go.

Add unit tests for uiMenu. Depends on #171 

Edit2: [Branch](https://github.com/szanni/libui-ng/tree/fix-uiMenu-uninit-cmocka) That combines the fixes in #171 with the tests here.