### PR TITLE
Fix uiNewMenu when initializing libui-ng a second time.

### DIFF
--- a/darwin/menu.m
+++ b/darwin/menu.m
@@ -365,4 +365,8 @@ void uiprivUninitMenus(void)
 		uiprivFree(m);
 	}];
 	[menus release];
+
+	/* Reset global state. */
+	menus = nil;
+	menusFinalized = NO;
 }

--- a/unix/menu.c
+++ b/unix/menu.c
@@ -364,4 +364,11 @@ void uiprivUninitMenus(void)
 		uiprivFree(m);
 	}
 	g_array_free(menus, TRUE);
+
+	/* Reset global state. */
+	menus = NULL;
+	menusFinalized = FALSE;
+	hasQuit = FALSE;
+	hasPreferences = FALSE;
+	hasAbout = FALSE;
 }

--- a/windows/menu.cpp
+++ b/windows/menu.cpp
@@ -366,4 +366,14 @@ void uninitMenus(void)
 	}
 	if (menus != NULL)
 		uiprivFree(menus);
+
+	/* Reset global state. */
+	menus = NULL;
+	len = 0;
+	cap = 0;
+	menusFinalized = FALSE;
+	curID = 100;
+	hasQuit = FALSE;
+	hasPreferences = FALSE;
+	hasAbout = FALSE;
 }


### PR DESCRIPTION
Reset the global variables on `uiprivUninit()` for all platforms.
This will should allow for re-initializing an application that contains menus.

From preliminary testing the code seems to work on all platforms. I tested Window7, Linux (gtk 3.24.35), macOS Big Sur. Hope I did not miss something.

Fixes #169

Edit: [Branch](https://github.com/szanni/libui-ng/tree/fix-uiMenu-uninit-cmocka) That combines the fixes here with the tests in #170.