### PR TITLE
uiMenu: Fix uiUninit() + cmocka tests + darwin: Remove uiprivMap()

### DIFF
--- a/darwin/menu.m
+++ b/darwin/menu.m
@@ -365,4 +365,8 @@ void uiprivUninitMenus(void)
 		uiprivFree(m);
 	}];
 	[menus release];
+
+	/* Reset global state. */
+	menus = nil;
+	menusFinalized = NO;
 }

--- a/darwin/menu.m
+++ b/darwin/menu.m
@@ -1,39 +1,83 @@
 // 28 april 2015
 #import "uipriv_darwin.h"
 
-static NSMutableArray *menus = nil;
-static BOOL menusFinalized = NO;
-
 struct uiMenu {
 	NSMenu *menu;
 	NSMenuItem *item;
-	NSMutableArray *items;
 };
 
 struct uiMenuItem {
-	NSMenuItem *item;
+	uiprivMenuItem *item;
 	int type;
 	BOOL disabled;
 	void (*onClicked)(uiMenuItem *, uiWindow *, void *);
 	void *onClickedData;
 };
 
-enum {
+enum uiprivMenuItemType {
 	typeRegular,
 	typeCheckbox,
 	typeQuit,
 	typePreferences,
 	typeAbout,
-	typeSeparator,
 };
 
-static void mapItemReleaser(void *key, void *value)
-{
-	uiMenuItem *item;
- 
-	item = (uiMenuItem *) value;
-	[item->item release];
+@interface uiprivMenu : NSMenu {
+@public
+	uiMenu *menu;
 }
+@end
+
+@implementation uiprivMenu
+- (id)initWithTitle:(NSString *)title uiMenu:(uiMenu *)m
+{
+	self = [super initWithTitle:title];
+	if (self) {
+		self->menu = m;
+	}
+	return self;
+}
+@end
+
+@implementation uiprivMenuItem
+- (id)initWithTitle:(NSString *)title uiMenuItem:(uiMenuItem *)i
+{
+	self = [super initWithTitle:title action:@selector(onClicked:) keyEquivalent:@""];
+	if (self) {
+		self->item = i;
+
+		[self setTarget:self];
+	}
+	return self;
+}
+
+- (IBAction)onClicked:(id)sender
+{
+	switch (self->item->type) {
+	case typeQuit:
+		if (uiprivShouldQuit())
+			uiQuit();
+		return;
+	case typeCheckbox:
+		uiMenuItemSetChecked(self->item, !uiMenuItemChecked(self->item));
+		// fall through
+	default:
+		// System menu items that may have no user callback (Preferences/About)
+		if (self->item == NULL)
+			break;
+		// use the key window as the source of the menu event; it's the active window
+		(*(self->item->onClicked))(self->item, uiprivWindowFromNSWindow([uiprivNSApp() keyWindow]),
+			self->item->onClickedData);
+		break;
+	}
+}
+
+- (void)setUiMenuItem:(uiMenuItem *)i
+{
+	self->item = i;
+}
+
+@end
 
 @implementation uiprivMenuManager
 
@@ -41,43 +85,33 @@ static void mapItemReleaser(void *key, void *value)
 {
 	self = [super init];
 	if (self) {
-		self->items = uiprivNewMap();
 		self->hasQuit = NO;
 		self->hasPreferences = NO;
 		self->hasAbout = NO;
+		self->finalized = NO;
 	}
 	return self;
 }
 
+- (BOOL)finalized
+{
+	return self->finalized;
+}
+
+- (void)finalize
+{
+	self->finalized = YES;
+}
+
 - (void)dealloc
 {
-	uiprivMapWalk(self->items, mapItemReleaser);
-	uiprivMapReset(self->items);
-	uiprivMapDestroy(self->items);
 	uiprivUninitMenus();
 	[super dealloc];
 }
 
-- (IBAction)onClicked:(id)sender
+- (void)register:(enum uiprivMenuItemType)type
 {
-	uiMenuItem *item;
-
-	item = (uiMenuItem *) uiprivMapGet(self->items, sender);
-	if (item->type == typeCheckbox)
-		uiMenuItemSetChecked(item, !uiMenuItemChecked(item));
-	// use the key window as the source of the menu event; it's the active window
-	(*(item->onClicked))(item, uiprivWindowFromNSWindow([uiprivNSApp() keyWindow]), item->onClickedData);
-}
-
-- (IBAction)onQuitClicked:(id)sender
-{
-	if (uiprivShouldQuit())
-		uiQuit();
-}
-
-- (void)register:(NSMenuItem *)item to:(uiMenuItem *)smi
-{
-	switch (smi->type) {
+	switch (type) {
 	case typeQuit:
 		if (self->hasQuit)
 			uiprivUserBug("You can't have multiple Quit menu items in one program.");
@@ -94,7 +128,6 @@ static void mapItemReleaser(void *key, void *value)
 		self->hasAbout = YES;
 		break;
 	}
-	uiprivMapSet(self->items, item, smi);
 }
 
 // on OS X there are two ways to handle menu items being enabled or disabled: automatically and manually
@@ -102,8 +135,6 @@ static void mapItemReleaser(void *key, void *value)
 // therefore, we have to handle enabling of the other options ourselves
 - (BOOL)validateMenuItem:(NSMenuItem *)item
 {
-	uiMenuItem *smi;
-
 	// disable the special items if they aren't present
 	if (item == self.quitItem && !self->hasQuit)
 		return NO;
@@ -112,8 +143,11 @@ static void mapItemReleaser(void *key, void *value)
 	if (item == self.aboutItem && !self->hasAbout)
 		return NO;
 	// then poll the item's enabled/disabled state
-	smi = (uiMenuItem *) uiprivMapGet(self->items, item);
-	return !smi->disabled;
+	if ([item isKindOfClass:[uiprivMenuItem class]]) {
+		uiprivMenuItem *mi = (uiprivMenuItem *)item;
+		return !mi->item->disabled;
+	}
+	return NO;
 }
 
 // Cocoa constructs the default application menu by hand for each program; that's what MainMenu.[nx]ib does
@@ -123,6 +157,7 @@ static void mapItemReleaser(void *key, void *value)
 	NSMenuItem *appMenuItem;
 	NSMenu *appMenu;
 	NSMenuItem *item;
+	uiprivMenuItem *pitem;
 	NSString *title;
 	NSMenu *servicesMenu;
 
@@ -135,18 +170,16 @@ static void mapItemReleaser(void *key, void *value)
 
 	// first is About
 	title = [@"About " stringByAppendingString:appName];
-	item = [[[NSMenuItem alloc] initWithTitle:title action:@selector(onClicked:) keyEquivalent:@""] autorelease];
-	[item setTarget:self];
-	[appMenu addItem:item];
-	self.aboutItem = item;
+	pitem = [[[uiprivMenuItem alloc] initWithTitle:title uiMenuItem:NULL] autorelease];
+	[appMenu addItem:pitem];
+	self.aboutItem = pitem;
 
 	[appMenu addItem:[NSMenuItem separatorItem]];
 
 	// next is Preferences
-	item = [[[NSMenuItem alloc] initWithTitle:@"Preferences…" action:@selector(onClicked:) keyEquivalent:@","] autorelease];
-	[item setTarget:self];
-	[appMenu addItem:item];
-	self.preferencesItem = item;
+	pitem = [[[uiprivMenuItem alloc] initWithTitle:@"Preferences\u2026" uiMenuItem:NULL] autorelease];
+	[appMenu addItem:pitem];
+	self.preferencesItem = pitem;
 
 	[appMenu addItem:[NSMenuItem separatorItem]];
 
@@ -176,10 +209,9 @@ static void mapItemReleaser(void *key, void *value)
 	// and finally Quit
 	// DON'T use @selector(terminate:) as the action; we handle termination ourselves
 	title = [@"Quit " stringByAppendingString:appName];
-	item = [[[NSMenuItem alloc] initWithTitle:title action:@selector(onQuitClicked:) keyEquivalent:@"q"] autorelease];
-	[item setTarget:self];
-	[appMenu addItem:item];
-	self.quitItem = item;
+	pitem = [[[uiprivMenuItem alloc] initWithTitle:title uiMenuItem:NULL] autorelease];
+	[appMenu addItem:pitem];
+	self.quitItem = pitem;
 }
 
 - (NSMenu *)makeMenubar
@@ -238,7 +270,7 @@ static uiMenuItem *newItem(uiMenu *m, int type, const char *name)
 
 	uiMenuItem *item;
 
-	if (menusFinalized)
+	if ([uiprivAppDelegate().menuManager finalized])
 		uiprivUserBug("You can't create a new menu item after menus have been finalized.");
 
 	item = uiprivNew(uiMenuItem);
@@ -246,29 +278,27 @@ static uiMenuItem *newItem(uiMenu *m, int type, const char *name)
 	item->type = type;
 	switch (item->type) {
 	case typeQuit:
-		item->item = [uiprivAppDelegate().menuManager.quitItem retain];
+		item->item = uiprivAppDelegate().menuManager.quitItem;
+		[item->item setUiMenuItem:item];
 		break;
 	case typePreferences:
-		item->item = [uiprivAppDelegate().menuManager.preferencesItem retain];
+		item->item = uiprivAppDelegate().menuManager.preferencesItem;
+		[item->item setUiMenuItem:item];
 		break;
 	case typeAbout:
-		item->item = [uiprivAppDelegate().menuManager.aboutItem retain];
-		break;
-	case typeSeparator:
-		item->item = [[NSMenuItem separatorItem] retain];
-		[m->menu addItem:item->item];
+		item->item = uiprivAppDelegate().menuManager.aboutItem;
+		[item->item setUiMenuItem:item];
 		break;
 	default:
-		item->item = [[NSMenuItem alloc] initWithTitle:uiprivToNSString(name) action:@selector(onClicked:) keyEquivalent:@""];
-		[item->item setTarget:uiprivAppDelegate().menuManager];
+		item->item = [[uiprivMenuItem alloc] initWithTitle:uiprivToNSString(name) uiMenuItem:item];
 		[m->menu addItem:item->item];
 		break;
 	}
 
-	[uiprivAppDelegate().menuManager register:item->item to:item];
-	item->onClicked = defaultOnClicked;
-
-	[m->items addObject:[NSValue valueWithPointer:item]];
+	[uiprivAppDelegate().menuManager register:item->type];
+	// typeQuit is handled via uiprivShouldQuit()
+	if (item->type != typeQuit)
+		uiMenuItemOnClicked(item, defaultOnClicked, NULL);
 
 	return item;
 
@@ -287,25 +317,22 @@ uiMenuItem *uiMenuAppendCheckItem(uiMenu *m, const char *name)
 
 uiMenuItem *uiMenuAppendQuitItem(uiMenu *m)
 {
-	// duplicate check is in the register:to: selector
 	return newItem(m, typeQuit, NULL);
 }
 
 uiMenuItem *uiMenuAppendPreferencesItem(uiMenu *m)
 {
-	// duplicate check is in the register:to: selector
 	return newItem(m, typePreferences, NULL);
 }
 
 uiMenuItem *uiMenuAppendAboutItem(uiMenu *m)
 {
-	// duplicate check is in the register:to: selector
 	return newItem(m, typeAbout, NULL);
 }
 
 void uiMenuAppendSeparator(uiMenu *m)
 {
-	newItem(m, typeSeparator, NULL);
+	[m->menu addItem:[NSMenuItem separatorItem]];
 }
 
 uiMenu *uiNewMenu(const char *name)
@@ -314,24 +341,18 @@ uiMenu *uiNewMenu(const char *name)
 
 	uiMenu *m;
 
-	if (menusFinalized)
+	if ([uiprivAppDelegate().menuManager finalized])
 		uiprivUserBug("You can't create a new menu after menus have been finalized.");
-	if (menus == nil)
-		menus = [NSMutableArray new];
 
 	m = uiprivNew(uiMenu);
 
-	m->menu = [[NSMenu alloc] initWithTitle:uiprivToNSString(name)];
+	m->menu = [[uiprivMenu alloc] initWithTitle:uiprivToNSString(name) uiMenu:m];
 	// use automatic menu item enabling for all menus for consistency's sake
 
 	m->item = [[NSMenuItem alloc] initWithTitle:uiprivToNSString(name) action:NULL keyEquivalent:@""];
 	[m->item setSubmenu:m->menu];
 
-	m->items = [NSMutableArray new];
-
 	[[uiprivNSApp() mainMenu] addItem:m->item];
-
-	[menus addObject:[NSValue valueWithPointer:m]];
 
 	return m;
 
@@ -340,33 +361,29 @@ uiMenu *uiNewMenu(const char *name)
 
 void uiprivFinalizeMenus(void)
 {
-	menusFinalized = YES;
+	[uiprivAppDelegate().menuManager finalize];
 }
 
 void uiprivUninitMenus(void)
 {
-	if (menus == NULL)
-		return;
-	[menus enumerateObjectsUsingBlock:^(id obj, NSUInteger index, BOOL *stop) {
-		NSValue *v;
-		uiMenu *m;
+	NSMenuItem *mi;
+	NSMenu *sm;
+	NSMenuItem *smi;
 
-		v = (NSValue *) obj;
-		m = (uiMenu *) [v pointerValue];
-		[m->items enumerateObjectsUsingBlock:^(id obj, NSUInteger index, BOOL *stop) {
-			NSValue *v;
-			uiMenuItem *mi;
-
-			v = (NSValue *) obj;
-			mi = (uiMenuItem *) [v pointerValue];
-			uiprivFree(mi);
-		}];
-		[m->items release];
-		uiprivFree(m);
-	}];
-	[menus release];
-
-	/* Reset global state. */
-	menus = nil;
-	menusFinalized = NO;
+	for (mi in [[uiprivNSApp() mainMenu] itemArray]) {
+		if ([mi hasSubmenu]) {
+			sm = [mi submenu];
+			for (smi in [sm itemArray]) {
+				if ([smi isKindOfClass:[uiprivMenuItem class]]) {
+					uiprivMenuItem *x = (uiprivMenuItem *)smi;
+					if (x->item != NULL)
+						uiprivFree(x->item);
+				}
+			}
+			if ([sm isKindOfClass:[uiprivMenu class]]) {
+				uiprivMenu *x = (uiprivMenu *)sm;
+				uiprivFree(x->menu);
+			}
+		}
+	}
 }

--- a/darwin/uipriv_darwin.h
+++ b/darwin/uipriv_darwin.h
@@ -34,18 +34,25 @@ extern void uiprivMapWalk(uiprivMap *m, void (*f)(void *key, void *value));
 extern void uiprivMapReset(uiprivMap *m);
 
 // menu.m
+@interface uiprivMenuItem : NSMenuItem {
+@public
+	uiMenuItem *item;
+}
+@end
 @interface uiprivMenuManager : NSObject {
-	uiprivMap *items;
 	BOOL hasQuit;
 	BOOL hasPreferences;
 	BOOL hasAbout;
+	BOOL finalized;
 }
-@property (strong) NSMenuItem *quitItem;
-@property (strong) NSMenuItem *preferencesItem;
-@property (strong) NSMenuItem *aboutItem;
+@property (strong) uiprivMenuItem *quitItem;
+@property (strong) uiprivMenuItem *preferencesItem;
+@property (strong) uiprivMenuItem *aboutItem;
 // NSMenuValidation is only informal
 - (BOOL)validateMenuItem:(NSMenuItem *)item;
 - (NSMenu *)makeMenubar;
+- (BOOL)finalized;
+- (void)finalize;
 @end
 extern void uiprivFinalizeMenus(void);
 extern void uiprivUninitMenus(void);

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -2,22 +2,11 @@
 
 #include "unit.h"
 
-#define UNIT_TEST_WIDTH 300
-#define UNIT_TEST_HEIGHT 200
-
-static int onClosing(uiWindow *w, void *data)
+int unitWindowOnClosingQuit(uiWindow *w, void *data)
 {
 	uiQuit();
 	return 1;
 }
-
-/*
-int close(void *data)
-{
-	uiQuit();
-	return 1;
-}
-*/
 
 int unitTestsSetup(void **state)
 {
@@ -38,8 +27,8 @@ int unitTestSetup(void **_state)
 	uiInitOptions o = {0};
 
 	assert_null(uiInit(&o));
-	state->w = uiNewWindow("Unit Test", UNIT_TEST_WIDTH, UNIT_TEST_HEIGHT, 0);
-	uiWindowOnClosing(state->w, onClosing, NULL);
+	state->w = uiNewWindow("Unit Test", UNIT_TEST_WINDOW_WIDTH, UNIT_TEST_WINDOW_HEIGHT, 0);
+	uiWindowOnClosing(state->w, unitWindowOnClosingQuit, NULL);
 	return 0;
 }
 

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -57,6 +57,7 @@ int main(void)
 	int failedComponents = 0;
 	struct unitTest unitTests[] = {
 		{ initRunUnitTests },
+		{ menuRunUnitTests },
 		{ sliderRunUnitTests },
 		{ spinboxRunUnitTests },
 		{ labelRunUnitTests },

--- a/test/unit/menu.c
+++ b/test/unit/menu.c
@@ -1,0 +1,143 @@
+#include "unit.h"
+
+int menuTestSetup(void **state);
+int menuTestTeardown(void **state);
+
+static void menuNew(void **state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+}
+
+static void menuNewInitTwice(void **state)
+{
+	uiMenu *m;
+
+	menuTestSetup(state);
+	m = uiNewMenu("Menu 1");
+	menuTestTeardown(state);
+
+	menuTestSetup(state);
+	m = uiNewMenu("Menu 2");
+	menuTestTeardown(state);
+}
+
+static void menuNewEmptyString(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("");
+}
+
+static void menuAppendItem(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendItem(m, "Item");
+}
+
+static void menuAppendItems(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendItem(m, "Item 1");
+	uiMenuAppendItem(m, "Item 2");
+}
+
+static void menuAppendCheckItem(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendCheckItem(m, "Item");
+}
+
+static void menuAppendCheckItems(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendCheckItem(m, "Item 1");
+	uiMenuAppendCheckItem(m, "Item 2");
+}
+
+static void menuAppendAboutItem(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendAboutItem(m);
+}
+
+static void menuAppendPreferencesItem(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendPreferencesItem(m);
+}
+
+static void menuAppendQuitItem(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendQuitItem(m);
+}
+
+static void menuAppendSeparator(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendSeparator(m);
+}
+
+int menuTestSetup(void **_state)
+{
+	uiInitOptions o = {0};
+
+	assert_null(uiInit(&o));
+	return 0;
+}
+
+int menuTestTeardown(void **_state)
+{
+	struct state *state = *_state;
+
+	state->w = uiNewWindow("Menu Test", UNIT_TEST_WINDOW_WIDTH, UNIT_TEST_WINDOW_HEIGHT, 1);
+	uiWindowOnClosing(state->w, unitWindowOnClosingQuit, NULL);
+
+	uiControlShow(uiControl(state->w));
+	uiMainSteps();
+	uiMainStep(1);
+	uiControlDestroy(uiControl(state->w));
+	uiUninit();
+	return 0;
+}
+
+#define menuUnitTest(f) cmocka_unit_test_setup_teardown((f), \
+		menuTestSetup, menuTestTeardown)
+
+int menuRunUnitTests(void)
+{
+	const struct CMUnitTest tests[] = {
+		menuUnitTest(menuNew),
+		cmocka_unit_test(menuNewInitTwice),
+		menuUnitTest(menuNewEmptyString),
+		menuUnitTest(menuAppendItem),
+		menuUnitTest(menuAppendItems),
+		menuUnitTest(menuAppendCheckItem),
+		menuUnitTest(menuAppendCheckItems),
+		menuUnitTest(menuAppendAboutItem),
+		menuUnitTest(menuAppendPreferencesItem),
+		menuUnitTest(menuAppendQuitItem),
+		menuUnitTest(menuAppendSeparator),
+	};
+
+	return cmocka_run_group_tests_name("uiMenu", tests, unitTestsSetup, unitTestsTeardown);
+}
+

--- a/test/unit/menu.c
+++ b/test/unit/menu.c
@@ -96,6 +96,79 @@ static void menuAppendSeparator(void **_state)
 	uiMenuAppendSeparator(m);
 }
 
+static void menuAppendFull(void **_state)
+{
+	uiMenu *m;
+
+	m = uiNewMenu("Menu");
+	uiMenuAppendItem(m, "Item");
+	uiMenuAppendSeparator(m);
+	uiMenuAppendCheckItem(m, "Check Item");
+	uiMenuAppendAboutItem(m);
+	uiMenuAppendPreferencesItem(m);
+	uiMenuAppendQuitItem(m);
+}
+
+static void menuItemEnable(void **_state)
+{
+	uiMenu *m;
+	uiMenuItem *i;
+
+	m = uiNewMenu("Menu");
+	i = uiMenuAppendItem(m, "Item");
+	uiMenuItemEnable(i);
+}
+
+static void menuItemDisable(void **_state)
+{
+	uiMenu *m;
+	uiMenuItem *i;
+
+	m = uiNewMenu("Menu");
+	i = uiMenuAppendItem(m, "Item");
+	uiMenuItemDisable(i);
+}
+
+static void menuItemCheckedDefaultFalse(void **_state)
+{
+	uiMenu *m;
+	uiMenuItem *i;
+
+	m = uiNewMenu("Menu");
+	i = uiMenuAppendCheckItem(m, "Item");
+	assert_int_equal(uiMenuItemChecked(i), 0);
+}
+
+static void menuItemSetChecked(void **_state)
+{
+	uiMenu *m;
+	uiMenuItem *i;
+
+	m = uiNewMenu("Menu");
+	i = uiMenuAppendCheckItem(m, "Item");
+	uiMenuItemSetChecked(i, 1);
+	assert_int_equal(uiMenuItemChecked(i), 1);
+	uiMenuItemSetChecked(i, 0);
+	assert_int_equal(uiMenuItemChecked(i), 0);
+}
+
+static void onClickedNoCall(uiMenuItem *i, uiWindow *w, void *data)
+{
+	function_called();
+}
+
+static void menuItemOnClicked(void **_state)
+{
+	uiMenu *m;
+	uiMenuItem *i;
+
+	m = uiNewMenu("Menu");
+	i = uiMenuAppendItem(m, "Item");
+	// FIXME: https://gitlab.com/cmocka/cmocka/-/issues/18
+	//expect_function_calls(onClickedNoCall, 0);
+	uiMenuItemOnClicked(i, onClickedNoCall, NULL);
+}
+
 int menuTestSetup(void **_state)
 {
 	uiInitOptions o = {0};
@@ -136,6 +209,12 @@ int menuRunUnitTests(void)
 		menuUnitTest(menuAppendPreferencesItem),
 		menuUnitTest(menuAppendQuitItem),
 		menuUnitTest(menuAppendSeparator),
+		menuUnitTest(menuAppendFull),
+		menuUnitTest(menuItemEnable),
+		menuUnitTest(menuItemDisable),
+		menuUnitTest(menuItemCheckedDefaultFalse),
+		menuUnitTest(menuItemSetChecked),
+		menuUnitTest(menuItemOnClicked),
 	};
 
 	return cmocka_run_group_tests_name("uiMenu", tests, unitTestsSetup, unitTestsTeardown);

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -11,6 +11,7 @@ libui_unit_sources = [
         'combobox.c',
         'checkbox.c',
         'radiobuttons.c',
+        'menu.c',
 ]
 
 if libui_OS == 'windows'

--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -30,6 +30,11 @@ struct state {
 	uiControl *c;
 };
 
+int unitWindowOnClosingQuit(uiWindow *w, void *data);
+
+#define UNIT_TEST_WINDOW_WIDTH 300
+#define UNIT_TEST_WINDOW_HEIGHT 200
+
 /**
  * Helper for setting up the state variable used in unit tests.
  */

--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -21,6 +21,7 @@ int buttonRunUnitTests(void);
 int comboboxRunUnitTests(void);
 int checkboxRunUnitTests(void);
 int radioButtonsRunUnitTests(void);
+int menuRunUnitTests(void);
 
 /**
  * Helper for general setup/teardown of controls embedded in a window.

--- a/unix/menu.c
+++ b/unix/menu.c
@@ -364,4 +364,11 @@ void uiprivUninitMenus(void)
 		uiprivFree(m);
 	}
 	g_array_free(menus, TRUE);
+
+	/* Reset global state. */
+	menus = NULL;
+	menusFinalized = FALSE;
+	hasQuit = FALSE;
+	hasPreferences = FALSE;
+	hasAbout = FALSE;
 }

--- a/windows/menu.cpp
+++ b/windows/menu.cpp
@@ -366,4 +366,14 @@ void uninitMenus(void)
 	}
 	if (menus != NULL)
 		uiprivFree(menus);
+
+	/* Reset global state. */
+	menus = NULL;
+	len = 0;
+	cap = 0;
+	menusFinalized = FALSE;
+	curID = 100;
+	hasQuit = FALSE;
+	hasPreferences = FALSE;
+	hasAbout = FALSE;
 }


### PR DESCRIPTION
- Fixes presented in #169 for all platforms pertaining uiMenu re-initialization
- Cmocka test cases for uiMenu #170
- Darwin: refactoring removing global state and uiprivMap() #165
- Darwin: fix memory leak of strings `"About unit"`, `"Quit unit"`

The existing memory leak around the NSObjects for `About`, `Preferences` and `Quit` still exists however.
Run `leaks --atExit -- ./build/meson-out/unit` to see what objects remain. Interestingly enough test case triggering the problem is `initUninitTwice`. I haven't been able to figure out who still holds a reference, I assume it has to do with the mixing of ARC, MRR and `@autoreleasepool`. But maybe the problem lies somewhere else, as the problem seemingly disappears when creating a window. 