### PR TITLE
darwin: remove singleton delegate for uiEntry + cmocka tests

### DIFF
--- a/darwin/entry.m
+++ b/darwin/entry.m
@@ -175,29 +175,12 @@ static void defaultOnChanged(uiEntry *e, void *data)
 	// do nothing
 }
 
-// these are based on interface builder defaults; my comments in the old code weren't very good so I don't really know what talked about what, sorry :/
-void uiprivFinishNewTextField(NSTextField *t, BOOL isEntry)
-{
-	uiDarwinSetControlFont(t, NSRegularControlSize);
-
-	// THE ORDER OF THESE CALLS IS IMPORTANT; CHANGE IT AND THE BORDERS WILL DISAPPEAR
-	[t setBordered:NO];
-	[t setBezelStyle:NSTextFieldSquareBezel];
-	[t setBezeled:isEntry];
-
-	// we don't need to worry about substitutions/autocorrect here; see window_darwin.m for details
-
-	[[t cell] setLineBreakMode:NSLineBreakByClipping];
-	[[t cell] setScrollable:YES];
-}
-
 static NSTextField *realNewEditableTextField(Class class)
 {
 	NSTextField *tf;
 
 	tf = [[class alloc] initWithFrame:NSZeroRect];
-	[tf setSelectable:YES];		// otherwise the setting is masked by the editable default of YES
-	uiprivFinishNewTextField(tf, YES);
+	[tf uiSetStyleEntry];
 	return tf;
 }
 
@@ -244,8 +227,6 @@ uiEntry *uiNewSearchEntry(void)
 	// TODO these are only on 10.10
 //	[s setSendsSearchStringImmediately:NO];
 //	[s setSendsWholeSearchString:NO];
-	[s setBordered:NO];
-	[s setBezelStyle:NSTextFieldRoundedBezel];
-	[s setBezeled:YES];
+	[s uiSetStyleSearchEntry];
 	return e;
 }

--- a/darwin/label.m
+++ b/darwin/label.m
@@ -27,7 +27,7 @@ NSTextField *uiprivNewLabel(NSString *str)
 	[tf setEditable:NO];
 	[tf setSelectable:NO];
 	[tf setDrawsBackground:NO];
-	uiprivFinishNewTextField(tf, NO);
+	[tf uiSetStyleLabel];
 	return tf;
 }
 

--- a/darwin/meson.build
+++ b/darwin/meson.build
@@ -51,6 +51,7 @@ libui_sources += [
 	'darwin/util.m',
 	'darwin/window.m',
 	'darwin/winmoveresize.m',
+	'darwin/nstextfield.m',
 ]
 
 libui_deps += [

--- a/darwin/nstextfield.m
+++ b/darwin/nstextfield.m
@@ -1,0 +1,34 @@
+#import "uipriv_darwin.h"
+
+@implementation NSTextField (ui)
+
+// Settings are based on the interface builder defaults.
+- (void)uiSetStyleLabel
+{
+	uiDarwinSetControlFont(self, NSRegularControlSize);
+
+	[self setBordered:NO];
+	[self setBezeled:NO];
+
+	// auto correct is handled in window_darwin.m
+	[[self cell] setLineBreakMode:NSLineBreakByClipping];
+	[[self cell] setScrollable:YES];
+}
+
+- (void)uiSetStyleEntry
+{
+	[self uiSetStyleLabel];
+
+	[self setSelectable:YES];
+	[self setBezeled:YES];
+	[self setBezelStyle:NSTextFieldSquareBezel];
+}
+
+- (void)uiSetStyleSearchEntry
+{
+	[self uiSetStyleEntry];
+
+	[self setBezelStyle:NSTextFieldRoundedBezel];
+}
+
+@end

--- a/darwin/uipriv_darwin.h
+++ b/darwin/uipriv_darwin.h
@@ -23,6 +23,13 @@
 #define NSAppKitVersionNumber10_9 1265
 #endif
 
+// nstextfield.m
+@interface NSTextField (ui)
+- (void)uiSetStyleLabel;
+- (void)uiSetStyleEntry;
+- (void)uiSetStyleSearchEntry;
+@end
+
 // map.m
 typedef struct uiprivMap uiprivMap;
 extern uiprivMap *uiprivNewMap(void);
@@ -73,7 +80,6 @@ extern int uiprivMainStep(uiprivNextEventArgs *nea, BOOL (^interceptEvent)(NSEve
 extern void uiprivDisableAutocorrect(NSTextView *);
 
 // entry.m
-extern void uiprivFinishNewTextField(NSTextField *, BOOL);
 extern NSTextField *uiprivNewEditableTextField(void);
 
 // window.m

--- a/meson.build
+++ b/meson.build
@@ -76,6 +76,8 @@ if libui_OS == 'darwin'
 	libui_arch = ['-arch', 'x86_64', '-arch', 'arm64']
 	add_global_arguments(libui_arch, language: libui_darwin_langs)
 	add_global_link_arguments(libui_arch, language: libui_darwin_langs)
+
+	add_global_link_arguments(['-ObjC'], language: ['objc'])
 endif
 
 if libui_MSVC

--- a/test/unit/entry.c
+++ b/test/unit/entry.c
@@ -1,0 +1,132 @@
+#include "unit.h"
+
+#define uiEntryPtrFromState(s) uiControlPtrFromState(uiEntry, s)
+
+static void entryNew(void **state)
+{
+}
+
+static void entryTextDefault(void **state)
+{
+	uiEntry **e = uiEntryPtrFromState(state);
+	const char *text = "";
+	char *rv;
+
+	rv = uiEntryText(*e);
+	assert_string_equal(rv, text);
+	uiFreeText(rv);
+}
+
+static void entrySetText(void **state)
+{
+	uiEntry **e = uiEntryPtrFromState(state);
+	const char *text1 = "Text 1";
+	const char *text2 = "Text 2";
+	char *rv;
+
+	uiEntrySetText(*e, text1);
+	rv = uiEntryText(*e);
+	assert_string_equal(rv, text1);
+	uiFreeText(rv);
+	uiEntrySetText(*e, text2);
+	rv = uiEntryText(*e);
+	assert_string_equal(rv, text2);
+	uiFreeText(rv);
+}
+
+static void onChangedNoCall(uiEntry *e, void *data)
+{
+	function_called();
+}
+
+static void entrySetTextNoCallback(void **state)
+{
+
+	uiEntry **e = uiEntryPtrFromState(state);
+
+	uiEntryOnChanged(*e, onChangedNoCall, NULL);
+	// FIXME: https://gitlab.com/cmocka/cmocka/-/issues/18
+	//expect_function_calls(onChangedNoCall, 0);
+	uiEntrySetText(*e, "Text 1");
+	uiEntrySetText(*e, "Text 2");
+}
+
+static void entryReadOnlyDefault(void **state)
+{
+	uiEntry **e = uiEntryPtrFromState(state);
+
+	assert_int_equal(uiEntryReadOnly(*e), 0);
+}
+
+static void entrySetReadOnly(void **state)
+{
+	uiEntry **e = uiEntryPtrFromState(state);
+
+	uiEntrySetReadOnly(*e, 1);
+	assert_int_equal(uiEntryReadOnly(*e), 1);
+	uiEntrySetReadOnly(*e, 0);
+	assert_int_equal(uiEntryReadOnly(*e), 0);
+}
+
+static int entryTestSetup(void **state)
+{
+	int rv = unitTestSetup(state);
+	if (rv != 0)
+		return rv;
+
+	uiEntry **e = uiEntryPtrFromState(state);
+	*e = uiNewEntry();
+
+	return 0;
+}
+
+static int passwordEntryTestSetup(void **state)
+{
+	int rv = unitTestSetup(state);
+	if (rv != 0)
+		return rv;
+
+	uiEntry **e = uiEntryPtrFromState(state);
+	*e = uiNewPasswordEntry();
+
+	return 0;
+}
+
+static int searchEntryTestSetup(void **state)
+{
+	int rv = unitTestSetup(state);
+	if (rv != 0)
+		return rv;
+
+	uiEntry **e = uiEntryPtrFromState(state);
+	*e = uiNewSearchEntry();
+
+	return 0;
+}
+
+#define entryUnitTest(f) cmocka_unit_test_setup_teardown((f), \
+		entryTestSetup, unitTestTeardown)
+
+#define passwordEntryUnitTest(f) cmocka_unit_test_setup_teardown((f), \
+		passwordEntryTestSetup, unitTestTeardown)
+
+#define searchEntryUnitTest(f) cmocka_unit_test_setup_teardown((f), \
+		searchEntryTestSetup, unitTestTeardown)
+
+#define entryUnitTests(f) entryUnitTest(f), passwordEntryUnitTest(f), \
+		searchEntryUnitTest(f)
+
+int entryRunUnitTests(void)
+{
+	const struct CMUnitTest tests[] = {
+		entryUnitTests(entryNew),
+		entryUnitTests(entryTextDefault),
+		entryUnitTests(entrySetText),
+		entryUnitTests(entrySetTextNoCallback),
+		entryUnitTests(entryReadOnlyDefault),
+		entryUnitTests(entrySetReadOnly),
+	};
+
+	return cmocka_run_group_tests_name("uiEntry", tests, unitTestsSetup, unitTestsTeardown);
+}
+

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -75,6 +75,7 @@ int main(void)
 		{ comboboxRunUnitTests },
 		{ checkboxRunUnitTests },
 		{ radioButtonsRunUnitTests },
+		{ entryRunUnitTests },
 	};
 
 	for (i = 0; i < sizeof(unitTests)/sizeof(*unitTests); ++i) {

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -11,6 +11,7 @@ libui_unit_sources = [
         'combobox.c',
         'checkbox.c',
         'radiobuttons.c',
+        'entry.c',
 ]
 
 if libui_OS == 'windows'

--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -21,6 +21,7 @@ int buttonRunUnitTests(void);
 int comboboxRunUnitTests(void);
 int checkboxRunUnitTests(void);
 int radioButtonsRunUnitTests(void);
+int entryRunUnitTests(void);
 
 /**
  * Helper for general setup/teardown of controls embedded in a window.


### PR DESCRIPTION
- uiEntry tests (depends on/supersedes #174)
- Refactors the darwin code to use Objective-C categories for entry/text styling.
- Removes the uiEntry singleton by assigning a delegate object.
- Removes problematic global state.

This should fix  #165 for uiEntry