### PR TITLE
darwin: Fix uiMenu memory leak.

### DIFF
--- a/darwin/uipriv_darwin.h
+++ b/darwin/uipriv_darwin.h
@@ -42,9 +42,10 @@
 	BOOL hasAbout;
 	BOOL finalized;
 }
-@property (strong) uiprivMenuItem *quitItem;
-@property (strong) uiprivMenuItem *preferencesItem;
-@property (strong) uiprivMenuItem *aboutItem;
+// TODO: replace with weak references in ARC
+@property (unsafe_unretained) uiprivMenuItem *quitItem;
+@property (unsafe_unretained) uiprivMenuItem *preferencesItem;
+@property (unsafe_unretained) uiprivMenuItem *aboutItem;
 // NSMenuValidation is only informal
 - (BOOL)validateMenuItem:(NSMenuItem *)item;
 - (NSMenu *)makeMenubar;


### PR DESCRIPTION
Fixes #173 by using the better lifetime qualifiers.

`leaks --atExit -- ./build/meson-out/unit` should report no more memory leaks.

Ideally we would want to use `weak`, but that qualifier only exists with ARC enabled. `unsafe_unretained` essentially gives us the same in non-ARC (sans the dangling pointer safeguard).