### PR TITLE
darwin: Replace NSTextfield protocol with plain C functions.

### DIFF
--- a/darwin/entry.m
+++ b/darwin/entry.m
@@ -160,7 +160,7 @@ static NSTextField *realNewEditableTextField(Class class)
 	NSTextField *tf;
 
 	tf = [[class alloc] initWithFrame:NSZeroRect];
-	[tf uiSetStyleEntry];
+	uiprivNSTextFieldSetStyleEntry(tf);
 	return tf;
 }
 
@@ -211,6 +211,6 @@ uiEntry *uiNewSearchEntry(void)
 	// TODO these are only on 10.10
 //	[s setSendsSearchStringImmediately:NO];
 //	[s setSendsWholeSearchString:NO];
-	[s uiSetStyleSearchEntry];
+	uiprivNSTextFieldSetStyleSearchEntry(s);
 	return e;
 }

--- a/darwin/label.m
+++ b/darwin/label.m
@@ -27,7 +27,7 @@ NSTextField *uiprivNewLabel(NSString *str)
 	[tf setEditable:NO];
 	[tf setSelectable:NO];
 	[tf setDrawsBackground:NO];
-	[tf uiSetStyleLabel];
+	uiprivNSTextFieldSetStyleLabel(tf);
 	return tf;
 }
 

--- a/darwin/nstextfield.m
+++ b/darwin/nstextfield.m
@@ -1,34 +1,31 @@
 #import "uipriv_darwin.h"
 
-@implementation NSTextField (ui)
-
 // Settings are based on the interface builder defaults.
-- (void)uiSetStyleLabel
+void uiprivNSTextFieldSetStyleLabel(NSTextField *t)
 {
-	uiDarwinSetControlFont(self, NSRegularControlSize);
+	uiDarwinSetControlFont(t, NSRegularControlSize);
 
-	[self setBordered:NO];
-	[self setBezeled:NO];
+	[t setBordered:NO];
+	[t setBezeled:NO];
 
 	// auto correct is handled in window_darwin.m
-	[[self cell] setLineBreakMode:NSLineBreakByClipping];
-	[[self cell] setScrollable:YES];
+	[[t cell] setLineBreakMode:NSLineBreakByClipping];
+	[[t cell] setScrollable:YES];
 }
 
-- (void)uiSetStyleEntry
+void uiprivNSTextFieldSetStyleEntry(NSTextField *t)
 {
-	[self uiSetStyleLabel];
+	uiprivNSTextFieldSetStyleLabel(t);
 
-	[self setSelectable:YES];
-	[self setBezeled:YES];
-	[self setBezelStyle:NSTextFieldSquareBezel];
+	[t setSelectable:YES];
+	[t setBezeled:YES];
+	[t setBezelStyle:NSTextFieldSquareBezel];
 }
 
-- (void)uiSetStyleSearchEntry
+void uiprivNSTextFieldSetStyleSearchEntry(NSTextField *t)
 {
-	[self uiSetStyleEntry];
+	uiprivNSTextFieldSetStyleEntry(t);
 
-	[self setBezelStyle:NSTextFieldRoundedBezel];
+	[t setBezelStyle:NSTextFieldRoundedBezel];
 }
 
-@end

--- a/darwin/uipriv_darwin.h
+++ b/darwin/uipriv_darwin.h
@@ -24,11 +24,9 @@
 #endif
 
 // nstextfield.m
-@interface NSTextField (ui)
-- (void)uiSetStyleLabel;
-- (void)uiSetStyleEntry;
-- (void)uiSetStyleSearchEntry;
-@end
+void uiprivNSTextFieldSetStyleLabel(NSTextField *t);
+void uiprivNSTextFieldSetStyleEntry(NSTextField *t);
+void uiprivNSTextFieldSetStyleSearchEntry(NSTextField *t);
 
 // menu.m
 @interface uiprivMenuItem : NSMenuItem {

--- a/meson.build
+++ b/meson.build
@@ -76,8 +76,6 @@ if libui_OS == 'darwin'
 	libui_arch = ['-arch', 'x86_64', '-arch', 'arm64']
 	add_global_arguments(libui_arch, language: libui_darwin_langs)
 	add_global_link_arguments(libui_arch, language: libui_darwin_langs)
-
-	add_global_link_arguments(['-ObjC'], language: ['objc'])
 endif
 
 if libui_MSVC


### PR DESCRIPTION
Protocols require the `-ObjC` linker flag when assembling binaries. This becomes burdensome when using libui-ng as a meson subproject.

Replacing the custom NSTextfield protocol with plain C functions solves this dilemma while having a slightly less fancy call signature.

Related to #152 - the existing protocols make #152 even worse. Removing them is a step in the right direction.