### PR TITLE
Update list of bindings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ PHP | [ui](https://github.com/krakjoe/ui)
 Python | [pylibui](https://github.com/joaoventura/pylibui)
 Ring | [RingLibui](https://github.com/ring-lang/ring/tree/master/extensions/ringlibui)
 Ruby | [libui-ruby](https://github.com/jamescook/libui-ruby), [LibUI](https://github.com/kojix2/libui), [Glimmer DSL for LibUI](https://github.com/AndyObtiva/glimmer-dsl-libui)
-Rust | [libui-ng-sys](https://github.com/norepimorphism/libui-ng-sys), [boing](https://github.com/norepimorphism/boing), [libui-rs](https://github.com/rust-native-ui/libui-rs)
+Rust | [libui-ng-sys](https://github.com/norepimorphism/libui-ng-sys), [boing](https://github.com/norepimorphism/boing), [libui-rs](https://github.com/rust-native-ui/libui-rs), [libui](https://github.com/libui-rs/libui)
 Scala | [scalaui](https://github.com/lolgab/scalaui)
 Swift | [libui-swift](https://github.com/sclukey/libui-swift)
 


### PR DESCRIPTION
I would like to introduce my libui-ng Rust binding to the binding list: [`libui`](https://github.com/libui-rs/libui)
_(For people knowing the original libui that is certainly confusing, for most in the Rust ecosystem it should not be :)_

Its actually a fork or continuation of [`iui`](https://github.com/rust-native-ui/libui-rs) (here listed as libui-rs), with the new features of libui-ng and of course a unique flavor to it. Like iui did before, libui-ng is also not compiled with the supplied build system (Meson + Ninja), but a custom build script calling the compilers directly to cut down on dependencies.

Please consider adding it to the list.