### PR TITLE
Add API for getting and setting window position.

### DIFF
--- a/darwin/window.m
+++ b/darwin/window.m
@@ -240,6 +240,34 @@ void uiWindowSetTitle(uiWindow *w, const char *title)
 	[w->window setTitle:uiprivToNSString(title)];
 }
 
+void uiWindowPosition(uiWindow *w, int *x, int *y)
+{
+	NSRect screen;
+	NSRect window;
+	int screenHeightSansMenu;
+
+	screen = [[w->window screen] visibleFrame];
+	// Visible screen (no menu, no dock) + dock height
+	screenHeightSansMenu = screen.size.height + screen.origin.y;
+
+	window = [w->window frame];
+	*x = window.origin.x;
+	*y = screenHeightSansMenu - window.origin.y - window.size.height;
+}
+
+void uiWindowSetPosition(uiWindow *w, int x, int y)
+{
+	NSRect screen;
+	int screenHeightSansMenu;
+
+	screen = [[w->window screen] visibleFrame];
+	// Visible screen (no menu, no dock) + dock height
+	screenHeightSansMenu = screen.size.height + screen.origin.y;
+
+	y = screenHeightSansMenu - y;
+	[w->window setFrameTopLeftPoint:NSMakePoint(x, y)];
+}
+
 void uiWindowContentSize(uiWindow *w, int *width, int *height)
 {
 	NSRect r;

--- a/test/page15.c
+++ b/test/page15.c
@@ -210,6 +210,7 @@ void onMoved(uiWindow *w, void *data)
 {
 	int x, y;
 
+	puts("PositionChanged");
 	uiWindowPosition(w, &x, &y);
 	uiSpinboxSetValue(posX, x);
 	uiSpinboxSetValue(posY, y);
@@ -228,7 +229,7 @@ static void updatesize(uiWindow *w)
 
 void onSize(uiWindow *w, void *data)
 {
-	printf("size\n");
+	puts("ContentSizeChanged");
 	updatesize(w);
 }
 

--- a/test/page15.c
+++ b/test/page15.c
@@ -163,6 +163,7 @@ uiWindowSetChild(w,uiControl(b));}
 }
 
 static uiSpinbox *width, *height;
+static uiSpinbox *posX, *posY;
 static uiCheckbox *fullscreen;
 
 static void sizeWidth(uiSpinbox *s, void *data)
@@ -183,6 +184,35 @@ static void sizeHeight(uiSpinbox *s, void *data)
 	uiWindowContentSize(w, &xp, &yp);
 	yp = uiSpinboxValue(height);
 	uiWindowSetContentSize(w, xp, yp);
+}
+
+static void posXChanged(uiSpinbox *s, void *data)
+{
+	uiWindow *w = uiWindow(data);
+	int x, y;
+
+	uiWindowPosition(w, &x, &y);
+	x = uiSpinboxValue(posX);
+	uiWindowSetPosition(w, x, y);
+}
+
+static void posYChanged(uiSpinbox *s, void *data)
+{
+	uiWindow *w = uiWindow(data);
+	int x, y;
+
+	uiWindowPosition(w, &x, &y);
+	y = uiSpinboxValue(posY);
+	uiWindowSetPosition(w, x, y);
+}
+
+void onMoved(uiWindow *w, void *data)
+{
+	int x, y;
+
+	uiWindowPosition(w, &x, &y);
+	uiSpinboxSetValue(posX, x);
+	uiSpinboxSetValue(posY, y);
 }
 
 static void updatesize(uiWindow *w)
@@ -230,15 +260,31 @@ uiBox *makePage15(uiWindow *w)
 	uiBoxAppend(page15, uiControl(hbox), 0);
 
 	uiBoxAppend(hbox, uiControl(uiNewLabel("Size")), 0);
-	width = uiNewSpinbox(INT_MIN, INT_MAX);
+	width = uiNewSpinbox(0, INT_MAX);
 	uiBoxAppend(hbox, uiControl(width), 1);
-	height = uiNewSpinbox(INT_MIN, INT_MAX);
+	height = uiNewSpinbox(0, INT_MAX);
 	uiBoxAppend(hbox, uiControl(height), 1);
-	fullscreen = uiNewCheckbox("Fullscreen");
-	uiBoxAppend(hbox, uiControl(fullscreen), 0);
 
 	uiSpinboxOnChanged(width, sizeWidth, w);
 	uiSpinboxOnChanged(height, sizeHeight, w);
+
+	hbox = newHorizontalBox();
+	uiBoxAppend(page15, uiControl(hbox), 0);
+
+	uiBoxAppend(hbox, uiControl(uiNewLabel("Position")), 0);
+	posX = uiNewSpinbox(INT_MIN, INT_MAX);
+	uiBoxAppend(hbox, uiControl(posX), 1);
+	posY = uiNewSpinbox(INT_MIN, INT_MAX);
+
+	uiSpinboxOnChanged(posX, posXChanged, w);
+	uiSpinboxOnChanged(posY, posYChanged, w);
+	uiWindowOnPositionChanged(w, onMoved, NULL);
+	onMoved(w, NULL);
+
+	uiBoxAppend(hbox, uiControl(posY), 1);
+	fullscreen = uiNewCheckbox("Fullscreen");
+	uiBoxAppend(page15, uiControl(fullscreen), 0);
+
 	uiCheckboxOnToggled(fullscreen, setFullscreen, w);
 	uiWindowOnContentSizeChanged(w, onSize, NULL);
 	updatesize(w);

--- a/ui.h
+++ b/ui.h
@@ -298,6 +298,32 @@ _UI_EXTERN char *uiWindowTitle(uiWindow *w);
 _UI_EXTERN void uiWindowSetTitle(uiWindow *w, const char *title);
 
 /**
+ * Gets the window position.
+ *
+ * Coordinates are measured from the top left corner of the screen.
+ *
+ * @param w uiWindow instance.
+ * @param[out] x X position of the window.
+ * @param[out] y Y position of the window.
+ * @note This method may return inaccurate or dummy values on Unix platforms.
+ * @memberof uiWindow
+ */
+_UI_EXTERN void uiWindowPosition(uiWindow *w, int *x, int *y);
+
+/**
+ * Moves the window to the specified position.
+ *
+ * Coordinates are measured from the top left corner of the screen.
+ *
+ * @param w uiWindow instance.
+ * @param x New x position of the window.
+ * @param y New y position of the window.
+ * @note This method is merely a hint and may be ignored on Unix platforms.
+ * @memberof uiWindow
+ */
+_UI_EXTERN void uiWindowSetPosition(uiWindow *w, int x, int y);
+
+/**
  * Gets the window content size.
  *
  * @param w uiWindow instance.

--- a/ui.h
+++ b/ui.h
@@ -324,6 +324,22 @@ _UI_EXTERN void uiWindowPosition(uiWindow *w, int *x, int *y);
 _UI_EXTERN void uiWindowSetPosition(uiWindow *w, int x, int y);
 
 /**
+ * Registers a callback for when the window moved.
+ *
+ * @param w uiWindow instance.
+ * @param f Callback function.\n
+ *          @p sender Back reference to the instance that triggered the callback.\n
+ *          @p senderData User data registered with the sender instance.\n
+ * @param data User data to be passed to the callback.
+ *
+ * @note Only one callback can be registered at a time.
+ * @note The callback is not triggered when calling uiWindowSetPosition().
+ * @memberof uiWindow
+ */
+_UI_EXTERN void uiWindowOnPositionChanged(uiWindow *w,
+	void (*f)(uiWindow *sender, void *senderData), void *data);
+
+/**
  * Gets the window content size.
  *
  * @param w uiWindow instance.

--- a/unix/window.c
+++ b/unix/window.c
@@ -150,6 +150,16 @@ void uiWindowSetTitle(uiWindow *w, const char *title)
 	gtk_window_set_title(w->window, title);
 }
 
+void uiWindowPosition(uiWindow *w, int *x, int *y)
+{
+	gtk_window_get_position(w->window, x, y);
+}
+
+void uiWindowSetPosition(uiWindow *w, int x, int y)
+{
+	gtk_window_move(w->window, x, y);
+}
+
 void uiWindowContentSize(uiWindow *w, int *width, int *height)
 {
 	GtkAllocation allocation;

--- a/windows/window.cpp
+++ b/windows/window.cpp
@@ -331,6 +331,21 @@ static void windowMonitorRect(HWND hwnd, RECT *r)
 	*r = mi.rcMonitor;
 }
 
+void uiWindowPosition(uiWindow *w, int *x, int *y)
+{
+	RECT r;
+
+	uiWindowsEnsureGetWindowRect(w->hwnd, &r);
+	*x = r.left;
+	*y = r.top;
+}
+
+void uiWindowSetPosition(uiWindow *w, int x, int y)
+{
+	if (SetWindowPos(w->hwnd, NULL, x, y, 0, 0, SWP_NOACTIVATE | SWP_NOSIZE | SWP_NOOWNERZORDER | SWP_NOZORDER) == 0)
+		logLastError(L"error setting window position");
+}
+
 void uiWindowContentSize(uiWindow *w, int *width, int *height)
 {
 	RECT r;


### PR DESCRIPTION
This is the continuation of #62. I cleaned up the code and added support for darwin.

The current implementation does _not_ allow for `NULL` to be passed, mimicking the behavior in `uiWindowContentSize()`. IMO this might be useful to add at some point, but that can easily be done globally at a later stage without breaking anything.

To be aware: this is currently limited in usefulness as we do not have an API for getting screen dimensions. It however allows us to place windows in the top left corner or restoring the previous position of windows (think same window placement after an application restart).

As noted in the docs, this may not/only partially work on Unix platforms, similar to most of the other `uiWindow` stuff. GTK is very clear about this in the docs.

You can test in `tester` on `page15`.
```c
void uiWindowPosition(uiWindow *w, int *x, int *y);
void uiWindowSetPosition(uiWindow *w, int x, int y);
void uiWindowOnPositionChanged(uiWindow *w, void (*f)(uiWindow *sender, void *senderData), void *data);
```

Tested on macOS Big Sur, Windows 7, Linux Gtk3.24.37 and wine 8.3.

Closes #62