### PR TITLE
unix: Fix uiWindowContentSizeChanged()

### DIFF
--- a/ui.h
+++ b/ui.h
@@ -390,9 +390,7 @@ _UI_EXTERN void uiWindowSetFullscreen(uiWindow *w, int fullscreen);
  *          @p senderData User data registered with the sender instance.
  * @param data User data to be passed to the callback.
  *
- * @todo Research if this gets called on uiWindowSetContentSize().
- *       The signal on unix does not seem to get masked. Fix this on all
- *       platforms and document the masking here.
+ * @note The callback is not triggered when calling uiWindowSetContentSize().
  * @note Only one callback can be registered at a time.
  * @memberof uiWindow
  */

--- a/unix/window.c
+++ b/unix/window.c
@@ -35,6 +35,8 @@ struct uiWindow {
 
 	gint cachedPosX;
 	gint cachedPosY;
+	gint cachedWidth;
+	gint cachedHeight;
 };
 
 static gboolean onClosing(GtkWidget *win, GdkEvent *e, gpointer data)
@@ -50,10 +52,16 @@ static gboolean onClosing(GtkWidget *win, GdkEvent *e, gpointer data)
 
 static void onSizeAllocate(GtkWidget *widget, GdkRectangle *allocation, gpointer data)
 {
+	int width, height;
 	uiWindow *w = uiWindow(data);
 
-	// TODO deal with spurious size-allocates
-	(*(w->onContentSizeChanged))(w, w->onContentSizeChangedData);
+	// Ignore spurious size-allocate events
+	uiWindowContentSize(w, &width, &height);
+	if (width != w->cachedWidth || height != w->cachedHeight) {
+		w->cachedWidth = width;
+		w->cachedHeight = height;
+		(*(w->onContentSizeChanged))(w, w->onContentSizeChangedData);
+	}
 }
 
 static gboolean onGetFocus(GtkWidget *win, GdkEvent *e, gpointer data)


### PR DESCRIPTION
This fixes `uiWindowOnContentsizeChanged()` getting triggered randomly on mouse moves as well as masking the callback on `uiWindowSetContentSize()` to match darwin, windows and other API calls.

Updated docs & removed `@todo`.