### PR TITLE
windows: Fix rendering of some controls when inside uiTab pages

### DIFF
--- a/windows/tab.cpp
+++ b/windows/tab.cpp
@@ -38,6 +38,8 @@ static void tabRelayout(uiTab *t)
 {
 	struct tabPage *page;
 	RECT r;
+	LONG_PTR controlID;
+	HWND insertAfter;
 
 	// first move the tab control itself
 	uiWindowsEnsureGetClientRect(t->hwnd, &r);
@@ -48,7 +50,10 @@ static void tabRelayout(uiTab *t)
 		return;
 	page = tabPage(t, curpage(t));
 	tabPageRect(t, &r);
+	controlID = 100;
+	insertAfter = NULL;
 	uiWindowsEnsureMoveWindowDuringResize(page->hwnd, r.left, r.top, r.right - r.left, r.bottom - r.top);
+	uiWindowsEnsureAssignControlIDZOrder(page->hwnd, &controlID, &insertAfter);
 }
 
 static void showHidePage(uiTab *t, LRESULT which, int hide)


### PR DESCRIPTION
Initial "fix" for the rendering artifacts in controls with dropdown content such as comboboxes: ~~Trigger a redraw of the tab page children on the next immediate frame draw after each window configure event of the tab control.~~

~~This introduces a small flicker on aggressive resizing of the window, but shouldn't notice any other performance issues like before. So that is an improvement over some controls just randomly missing from the tab page..~~

See the old issue with test case to reproduce: https://github.com/andlabs/ui/issues/380#issuecomment-786319626
Also `controlgallery` -> `Numbers and Lists`