### PR TITLE
unix: Fix uiMsgBoxError()

### DIFF
--- a/unix/stddialogs.c
+++ b/unix/stddialogs.c
@@ -56,6 +56,11 @@ static void msgbox(GtkWindow *parent, const char *title, const char *description
 		type, buttons,
 		"%s", title);
 	gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(md), "%s", description);
+	if (type == GTK_MESSAGE_ERROR) {
+		gtk_message_dialog_set_image(GTK_MESSAGE_DIALOG(md),
+			gtk_image_new_from_icon_name("dialog-warning", GTK_ICON_SIZE_DIALOG));
+		gtk_widget_show_all(md);
+	}
 	gtk_dialog_run(GTK_DIALOG(md));
 	gtk_widget_destroy(md);
 }


### PR DESCRIPTION
Recent Gtk3 versions ignore the hint `GTK_MESSAGE_ERROR`, and render all message dialogs the same now:

<img src="https://user-images.githubusercontent.com/11763424/235344935-2c6cdebc-0522-4870-af98-9e86e484ebfd.png" width="439" height="151">

<img src="https://user-images.githubusercontent.com/11763424/235344942-ad1a302a-e305-4bb1-aaa3-2b9a8d9fffe4.png" width="474" height="151">

This PR restores the old behavior:

<img src="https://user-images.githubusercontent.com/11763424/235345232-f14395c4-6866-41ca-8f07-0f1314ef7b17.png" width="552" height="151">
