### PR TITLE
Fix indentation in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,31 +22,31 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Ubuntu-${{ matrix.arch }}-${{ matrix.libtype }}
     steps:
-    - name: Install Meson and Linux Deps
-      run: |
-        python3 -m pip install --upgrade pip setuptools wheel
-        pip3 install meson ninja
-        sudo apt-get update -y
-        sudo apt-get install -y libgtk-3-dev xvfb
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Meson Setup Build
-      run: meson setup builddir --buildtype=${{ matrix.buildtype }} --default-library=${{ matrix.libtype }}
-    - name: Ninja Build
-      run: ninja -C builddir --verbose
-    - name: Run Tests
-      run: xvfb-run meson test -C builddir --verbose
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: Ubuntu-${{ matrix.arch }}-${{ matrix.libtype }}-${{ matrix.buildtype }}
-        # lib + header + examples + test + build-log
-        path: |
-          !builddir/meson-out/*.p/
-          builddir/meson-out/*
-          ui_unix.h
-          ui.h
-          builddir/meson-logs/*.txt
+      - name: Install Meson and Linux Deps
+        run: |
+          python3 -m pip install --upgrade pip setuptools wheel
+          pip3 install meson ninja
+          sudo apt-get update -y
+          sudo apt-get install -y libgtk-3-dev xvfb
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Meson Setup Build
+        run: meson setup builddir --buildtype=${{ matrix.buildtype }} --default-library=${{ matrix.libtype }}
+      - name: Ninja Build
+        run: ninja -C builddir --verbose
+      - name: Run Tests
+        run: xvfb-run meson test -C builddir --verbose
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Ubuntu-${{ matrix.arch }}-${{ matrix.libtype }}-${{ matrix.buildtype }}
+          # lib + header + examples + test + build-log
+          path: |
+            !builddir/meson-out/*.p/
+            builddir/meson-out/*
+            ui_unix.h
+            ui.h
+            builddir/meson-logs/*.txt
 
   meson-windows:
     strategy:


### PR DESCRIPTION
This only corrects the indentation of the YAML file.

Background:
For Ruby users who want to use the latest libui-ng, I have slightly rewritten build.yml to build the shared library for Windows and arm-linux with GitHub Actions. I noticed this indentation error when I looked at the difference between the original build.yml and the modified [pre-build.yml](https://github.com/kojix2/libui-ng/blob/pre-build/.github/workflows/build.yml).