### PR TITLE
Add workflow_dispatch to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   meson-linux:


### PR DESCRIPTION
GitHub Actions will automatically remove the artifact after 90 days.
Thus the latest builds are often unavailable.

This pull request simply adds workflow_dispatch: anyone who forks the libui-ng repository will be able to run the build workflow on GitHub with the push of a button from their browser. Thus, if GitHub removes the artifact, you can immediately do the build and have a link to it ready. (However, nightly.link may not work well)

By the way, what I really want is not static libraries, but a distribution of shared libraries needed to create bindings for other languages. Let's talk about that some other time.