### PR TITLE
Tweaks to facilitate bindings from other languages

### DIFF
--- a/common/control.c
+++ b/common/control.c
@@ -74,6 +74,11 @@ void uiFreeControl(uiControl *c)
 {
 	if (uiControlParent(c) != NULL)
 		uiprivUserBug("You cannot destroy a uiControl while it still has a parent. (control: %p)", c);
+
+	if (c->onFreeData) {
+		(*(c->onFree))(c, c->onFreeData);
+	}
+
 	uiprivFree(c);
 }
 
@@ -98,4 +103,10 @@ int uiControlEnabledToUser(uiControl *c)
 		c = uiControlParent(c);
 	}
 	return 1;
+}
+
+void uiControlOnFree(uiControl *w, void (*f)(uiControl *, void *senderData), void *data)
+{
+	w->onFree = f;
+	w->onFreeData = data;
 }

--- a/darwin/area.m
+++ b/darwin/area.m
@@ -33,6 +33,8 @@ struct uiArea {
 	uiAreaHandler *ah;
 	BOOL scrolling;
 	NSEvent *dragevent;
+
+	void *userData;
 };
 
 @implementation areaView
@@ -493,4 +495,14 @@ uiArea *uiNewScrollingArea(uiAreaHandler *ah, int width, int height)
 	a->view = a->sv;
 
 	return a;
+}
+
+void* uiAreaGetUserData(uiArea *a)
+{
+	return a->userData;
+}
+
+void uiAreaSetUserData(uiArea *a, void *userData)
+{
+	a->userData = userData;
 }

--- a/darwin/table.h
+++ b/darwin/table.h
@@ -8,6 +8,7 @@ struct uiTableModel {
 	uiTableModelHandler *mh;
 	uiprivTableModel *m;
 	NSMutableArray *tables;
+	void *userData;
 };
 struct uiTable {
 	uiDarwinControl c;

--- a/darwin/table.m
+++ b/darwin/table.m
@@ -456,3 +456,13 @@ void uiTableColumnSetWidth(uiTable *t, int column, int width)
 	else
 		[tc setWidth: width];
 }
+
+void* uiTableModelGetUserData(uiTableModel *m)
+{
+	return m->userData;
+}
+
+void uiTableModelSetUserData(uiTableModel *m, void *userData)
+{
+	m->userData = userData;
+}

--- a/ui.h
+++ b/ui.h
@@ -2062,7 +2062,7 @@ _UI_EXTERN uiArea *uiNewScrollingArea(uiAreaHandler *ah, int width, int height);
  * @returns pointer to the user data structure.
  * @memberof uiArea
  */
-void* uiAreaGetUserData(uiArea *m);
+_UI_EXTERN void* uiAreaGetUserData(uiArea *m);
 
 /**
  * Sets the user data associated with the uiTableModel.
@@ -2071,7 +2071,7 @@ void* uiAreaGetUserData(uiArea *m);
  * @param userData pointer to the user data structure.
  * @memberof uiArea
  */
-void uiAreaSetUserData(uiArea *a, void *userData);
+_UI_EXTERN void uiAreaSetUserData(uiArea *a, void *userData);
 
 struct uiAreaDrawParams {
 	uiDrawContext *Context;
@@ -3435,7 +3435,7 @@ typedef struct uiTableModel uiTableModel;
  * @returns pointer to the user data structure.
  * @memberof uiTableModel
  */
-void* uiTableModelGetUserData(uiTableModel *m);
+_UI_EXTERN void* uiTableModelGetUserData(uiTableModel *m);
 
 /**
  * Sets the user data associated with the uiTableModel.
@@ -3444,7 +3444,7 @@ void* uiTableModelGetUserData(uiTableModel *m);
  * @param userData pointer to the user data structure.
  * @memberof uiTableModel
  */
-void uiTableModelSetUserData(uiTableModel *m, void *userData);
+_UI_EXTERN void uiTableModelSetUserData(uiTableModel *m, void *userData);
 
 /**
  * Developer defined methods for data retrieval and setting.

--- a/ui.h
+++ b/ui.h
@@ -106,6 +106,9 @@ struct uiControl {
 	int (*Enabled)(uiControl *);
 	void (*Enable)(uiControl *);
 	void (*Disable)(uiControl *);
+
+	void (*onFree)(uiControl *, void *);
+	void *onFreeData;
 };
 // TOOD add argument names to all arguments
 #define uiControl(this) ((uiControl *) (this))
@@ -208,6 +211,20 @@ _UI_EXTERN void uiControlEnable(uiControl *c);
  * @memberof uiControl
  */
 _UI_EXTERN void uiControlDisable(uiControl *c);
+
+/**
+ * Registers a callback for when the control is about to be freed.
+ *
+ * @param c uiControl instance.
+ * @param f Callback function.\n
+ *          @p sender Back reference to the instance that triggered the callback.\n
+ *          @p senderData User data registered with the sender instance.\n
+ * @param data User data to be passed to the callback.
+ *
+ * @note Only one callback can be registered at a time.
+ * @memberof uiControl
+ */
+_UI_EXTERN void uiControlOnFree(uiControl *w, void (*f)(uiControl *sender, void *senderData), void *data);
 
 /**
  * Allocates a uiControl.
@@ -2001,6 +2018,8 @@ struct uiAreaHandler {
 	void (*MouseCrossed)(uiAreaHandler *, uiArea *, int left);
 	void (*DragBroken)(uiAreaHandler *, uiArea *);
 	int (*KeyEvent)(uiAreaHandler *, uiArea *, uiAreaKeyEvent *);
+
+	void *userData;
 };
 
 // TODO RTL layouts?
@@ -2035,6 +2054,24 @@ _UI_EXTERN void uiAreaBeginUserWindowMove(uiArea *a);
 _UI_EXTERN void uiAreaBeginUserWindowResize(uiArea *a, uiWindowResizeEdge edge);
 _UI_EXTERN uiArea *uiNewArea(uiAreaHandler *ah);
 _UI_EXTERN uiArea *uiNewScrollingArea(uiAreaHandler *ah, int width, int height);
+
+/**
+ * Returns the user data associated with the uiTableModel.
+ *
+ * @param a Area to read.
+ * @returns pointer to the user data structure.
+ * @memberof uiArea
+ */
+void* uiAreaGetUserData(uiArea *m);
+
+/**
+ * Sets the user data associated with the uiTableModel.
+ *
+ * @param a uiArea to configure.
+ * @param userData pointer to the user data structure.
+ * @memberof uiArea
+ */
+void uiAreaSetUserData(uiArea *a, void *userData);
 
 struct uiAreaDrawParams {
 	uiDrawContext *Context;
@@ -3392,6 +3429,24 @@ _UI_ENUM(uiSortIndicator) {
 typedef struct uiTableModel uiTableModel;
 
 /**
+ * Returns the user data associated with the uiTableModel.
+ *
+ * @param m Table model to read.
+ * @returns pointer to the user data structure.
+ * @memberof uiTableModel
+ */
+void* uiTableModelGetUserData(uiTableModel *m);
+
+/**
+ * Sets the user data associated with the uiTableModel.
+ *
+ * @param m Table model to configure.
+ * @param userData pointer to the user data structure.
+ * @memberof uiTableModel
+ */
+void uiTableModelSetUserData(uiTableModel *m, void *userData);
+
+/**
  * Developer defined methods for data retrieval and setting.
  *
  * These methods get called whenever the associated uiTableModel needs to
@@ -3456,6 +3511,8 @@ struct uiTableModelHandler {
 	 * set by a uiTable.
 	 */
 	void (*SetCellValue)(uiTableModelHandler *, uiTableModel *, int, int, const uiTableValue *);
+
+	void *userData;
 };
 
 /**

--- a/unix/area.c
+++ b/unix/area.c
@@ -49,6 +49,8 @@ struct uiArea {
 
 	// for user window drags
 	GdkEventButton *dragevent;
+
+	void *userData;
 };
 
 G_DEFINE_TYPE(areaWidget, areaWidget, GTK_TYPE_DRAWING_AREA)
@@ -634,4 +636,14 @@ uiArea *uiNewScrollingArea(uiAreaHandler *ah, int width, int height)
 	gtk_widget_show(a->areaWidget);
 
 	return a;
+}
+
+void* uiAreaGetUserData(uiArea *a)
+{
+	return a->userData;
+}
+
+void uiAreaSetUserData(uiArea *a, void *userData)
+{
+	a->userData = userData;
 }

--- a/unix/table.c
+++ b/unix/table.c
@@ -900,3 +900,12 @@ void uiTableSetSelectionMode(uiTable *t, uiTableSelectionMode mode)
 	g_signal_handler_unblock(selection, t->onSelectionChangedSignal);
 }
 
+void* uiTableModelGetUserData(uiTableModel *m)
+{
+	return m->userData;
+}
+
+void uiTableModelSetUserData(uiTableModel *m, void *userData)
+{
+	m->userData = userData;
+}

--- a/unix/table.h
+++ b/unix/table.h
@@ -13,6 +13,7 @@ struct uiTableModel {
 	GObject parent_instance;
 	gint stamp;
 	uiTableModelHandler *mh;
+	void *userData;
 };
 struct uiTableModelClass {
 	GObjectClass parent_class;

--- a/windows/area.cpp
+++ b/windows/area.cpp
@@ -204,3 +204,13 @@ uiArea *uiNewScrollingArea(uiAreaHandler *ah, int width, int height)
 
 	return a;
 }
+
+void* uiAreaGetUserData(uiArea *a)
+{
+	return a->userData;
+}
+
+void uiAreaSetUserData(uiArea *a, void *userData)
+{
+	a->userData = userData;
+}

--- a/windows/area.hpp
+++ b/windows/area.hpp
@@ -26,6 +26,8 @@ struct uiArea {
 	BOOL tracking;
 
 	ID2D1HwndRenderTarget *rt;
+
+	void *userData;
 };
 
 // areadraw.cpp

--- a/windows/table.cpp
+++ b/windows/table.cpp
@@ -883,3 +883,13 @@ void uiTableColumnSetWidth(uiTable *t, int column, int width)
 
 	SendMessageW(t->hwnd, LVM_SETCOLUMNWIDTH, (WPARAM) column, (LPARAM) width);
 }
+
+void* uiTableModelGetUserData(uiTableModel *m)
+{
+	return m->userData;
+}
+
+void uiTableModelSetUserData(uiTableModel *m, void *userData)
+{
+	m->userData = userData;
+}

--- a/windows/table.hpp
+++ b/windows/table.hpp
@@ -8,6 +8,7 @@
 struct uiTableModel {
 	uiTableModelHandler *mh;
 	std::vector<uiTable *> *tables;
+	void *userData;
 };
 typedef struct uiprivTableColumnParams uiprivTableColumnParams;
 struct uiprivTableColumnParams {


### PR DESCRIPTION
Hello, thanks for continuing the development of libui!

This pull requests adds a couple of small modifications to facilitate implementing bindings from other languages, in this case the [Ardillo extension](https://github.com/ardillo-php/ext) for PHP.

The first modification concerns destroying of UI controls, the issue being some controls could be destroyed outside of the purview of the embedding application, possibly leading to memory safety issues. In order to keep the implementing application in the loop, it implements an `onFree` callback for `uiControl` structures (and it's corresponding context as `onFreeData`).

The second modification affects structures passed as parameters to various handlers which do not carry any context data (i.e. to match them back to their corresponding structures from the embedding environment). We found that `uiArea` and `uiTableModel` structures do not provide a straightforward correlation mechanism so we added `userData` structure members and corresponding `...GetUserData` and `...SetUserData` functions to retrieve/set them.

I'm happy to maintain a synchronized fork with these modifications yet these modifications might be useful for other similar projects, hence they're presented here for your consideration.