### PR TITLE
unit: Suppress `set but unused` warning in menu creation tests.

### DIFF
--- a/test/unit/menu.c
+++ b/test/unit/menu.c
@@ -8,6 +8,7 @@ static void menuNew(void **state)
 	uiMenu *m;
 
 	m = uiNewMenu("Menu");
+	(void)m;
 }
 
 static void menuNewInitTwice(void **state)
@@ -21,6 +22,8 @@ static void menuNewInitTwice(void **state)
 	menuTestSetup(state);
 	m = uiNewMenu("Menu 2");
 	menuTestTeardown(state);
+
+	(void)m;
 }
 
 static void menuNewEmptyString(void **_state)
@@ -28,6 +31,7 @@ static void menuNewEmptyString(void **_state)
 	uiMenu *m;
 
 	m = uiNewMenu("");
+	(void)m;
 }
 
 static void menuAppendItem(void **_state)


### PR DESCRIPTION
Suppress the 3 warnings emitted in `test/unit/menu.c`:
```sh
../test/unit/menu.c: In function ‘menuNew’:
../test/unit/menu.c:8:17: warning: variable ‘m’ set but not used [-Wunused-but-set-variable]
    8 |         uiMenu *m;
      |                 ^
../test/unit/menu.c: In function ‘menuNewInitTwice’:
../test/unit/menu.c:15:17: warning: variable ‘m’ set but not used [-Wunused-but-set-variable]
   15 |         uiMenu *m;
      |                 ^
../test/unit/menu.c: In function ‘menuNewEmptyString’:
../test/unit/menu.c:28:17: warning: variable ‘m’ set but not used [-Wunused-but-set-variable]
   28 |         uiMenu *m;
      |                 ^
```