### PR TITLE
 darwin: Fix uiMenuItem enable/disable and resulting segfaults. 

### DIFF
--- a/darwin/menu.m
+++ b/darwin/menu.m
@@ -77,6 +77,18 @@ enum uiprivMenuItemType {
 	self->item = i;
 }
 
+// Manually enable/disable menu items
+- (BOOL)validateMenuItem:(NSMenuItem *)menuItem
+{
+	uiprivMenuItem *i = (uiprivMenuItem *)menuItem;
+
+	// System menu item (Quit/Preferences/About) that has not been user created (yet)
+	if (i->item == NULL)
+		return NO;
+
+	return !i->item->disabled;
+}
+
 @end
 
 @implementation uiprivMenuManager
@@ -128,26 +140,6 @@ enum uiprivMenuItemType {
 		self->hasAbout = YES;
 		break;
 	}
-}
-
-// on OS X there are two ways to handle menu items being enabled or disabled: automatically and manually
-// unfortunately, the application menu requires automatic menu handling for the Hide, Hide Others, and Show All items to work correctly
-// therefore, we have to handle enabling of the other options ourselves
-- (BOOL)validateMenuItem:(NSMenuItem *)item
-{
-	// disable the special items if they aren't present
-	if (item == self.quitItem && !self->hasQuit)
-		return NO;
-	if (item == self.preferencesItem && !self->hasPreferences)
-		return NO;
-	if (item == self.aboutItem && !self->hasAbout)
-		return NO;
-	// then poll the item's enabled/disabled state
-	if ([item isKindOfClass:[uiprivMenuItem class]]) {
-		uiprivMenuItem *mi = (uiprivMenuItem *)item;
-		return !mi->item->disabled;
-	}
-	return NO;
 }
 
 // Cocoa constructs the default application menu by hand for each program; that's what MainMenu.[nx]ib does

--- a/darwin/menu.m
+++ b/darwin/menu.m
@@ -53,6 +53,12 @@ enum uiprivMenuItemType {
 
 - (IBAction)onClicked:(id)sender
 {
+	// System menu item (Quit/Preferences/About) that has not been user created (yet)
+	if (self->item == NULL) {
+		uiprivImplBug("Clicked nonexistent uiMenuItem which should be impossible");
+		return;
+	}
+
 	switch (self->item->type) {
 	case typeQuit:
 		if (uiprivShouldQuit())
@@ -62,9 +68,6 @@ enum uiprivMenuItemType {
 		uiMenuItemSetChecked(self->item, !uiMenuItemChecked(self->item));
 		// fall through
 	default:
-		// System menu items that may have no user callback (Preferences/About)
-		if (self->item == NULL)
-			break;
 		// use the key window as the source of the menu event; it's the active window
 		(*(self->item->onClicked))(self->item, uiprivWindowFromNSWindow([uiprivNSApp() keyWindow]),
 			self->item->onClickedData);

--- a/darwin/uipriv_darwin.h
+++ b/darwin/uipriv_darwin.h
@@ -33,6 +33,7 @@ void uiprivNSTextFieldSetStyleSearchEntry(NSTextField *t);
 @public
 	uiMenuItem *item;
 }
+- (BOOL)validateMenuItem:(NSMenuItem *)menuItem;
 @end
 @interface uiprivMenuManager : NSObject {
 	BOOL hasQuit;
@@ -44,8 +45,6 @@ void uiprivNSTextFieldSetStyleSearchEntry(NSTextField *t);
 @property (unsafe_unretained) uiprivMenuItem *quitItem;
 @property (unsafe_unretained) uiprivMenuItem *preferencesItem;
 @property (unsafe_unretained) uiprivMenuItem *aboutItem;
-// NSMenuValidation is only informal
-- (BOOL)validateMenuItem:(NSMenuItem *)item;
 - (NSMenu *)makeMenubar;
 - (BOOL)finalized;
 - (void)finalize;


### PR DESCRIPTION
Fix the regression introduced in https://github.com/libui-ng/libui-ng/commit/9e08072fc207d8392075e0c2c8b9c8fa11583bb2 which makes disabling uiMenuItems impossible on macOS.

Nonexistent system menu items are now disabled by default again. And I removed some unreachable code and hardened the onClick handler against future segfaults.

I removed the weird literature around OS X menu handling in the comment, as I did not find it helpful in understanding what was happening in the slightest. Happy to reintroduce that though, if desired.

Fixes #230 