### PR TITLE
Fix windows entry long text scroll.

### DIFF
--- a/test/qa/entry.c
+++ b/test/qa/entry.c
@@ -154,3 +154,24 @@ uiControl* searchEntryOnChanged()
 	return uiControl(vbox);
 }
 
+const char *entryLongTextGuide() {
+	return
+	"1.\tYou should see a text entry box containing the text\n"
+	"\t`abcdefghijklmnopqrstuvwxyz`. No scrolling on your part should be\n"
+	"\tnecessary to see the entire string.\n"
+	;
+}
+
+uiControl* entryLongText()
+{
+	uiBox *vbox;
+	uiEntry *entry;
+
+	vbox = uiNewVerticalBox();
+	entry = uiNewEntry();
+	uiEntrySetText(entry, "abcdefghijklmnopqrstuvwxyz");
+	uiBoxAppend(vbox, uiControl(entry), 0);
+
+	return uiControl(vbox);
+}
+

--- a/test/qa/entry.c
+++ b/test/qa/entry.c
@@ -175,3 +175,26 @@ uiControl* entryLongText()
 	return uiControl(vbox);
 }
 
+const char *entryOverflowTextGuide() {
+	return
+	"1.\tYou should see a text entry box containing text that overflows.\n"
+	"\tThe left most side of the entry should read `aaaabbbbccccddd...`.\n"
+	"\tYou should not see the end of the text `...xxxyyyyzzzz` without\n"
+	"\tscrolling manually.\n"
+	;
+}
+
+uiControl* entryOverflowText()
+{
+	uiBox *vbox;
+	uiEntry *entry;
+
+	vbox = uiNewVerticalBox();
+	entry = uiNewEntry();
+	uiEntrySetText(entry, "aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllll"
+		"mmmmnnnnooooppppqqqqrrrrssssttttuuuuvvvvwwwwxxxxyyyyzzzz");
+	uiBoxAppend(vbox, uiControl(entry), 0);
+
+	return uiControl(vbox);
+}
+

--- a/test/qa/main.c
+++ b/test/qa/main.c
@@ -30,6 +30,7 @@ struct controlTestCase entryTestCases[] = {
 	QA_TEST("2. Password Entry OnChanged Callback", passwordEntryOnChanged),
 	QA_TEST("3. Search Entry OnChanged Callback", searchEntryOnChanged),
 	QA_TEST("4. Entry Long Text", entryLongText),
+	QA_TEST("5. Entry Overflow Text", entryOverflowText),
 	{NULL, NULL, NULL}
 };
 

--- a/test/qa/main.c
+++ b/test/qa/main.c
@@ -29,6 +29,7 @@ struct controlTestCase entryTestCases[] = {
 	QA_TEST("1. Entry OnChanged Callback", entryOnChanged),
 	QA_TEST("2. Password Entry OnChanged Callback", passwordEntryOnChanged),
 	QA_TEST("3. Search Entry OnChanged Callback", searchEntryOnChanged),
+	QA_TEST("4. Entry Long Text", entryLongText),
 	{NULL, NULL, NULL}
 };
 

--- a/test/qa/qa.h
+++ b/test/qa/qa.h
@@ -18,6 +18,7 @@ QA_DECLARE_TEST(entryOnChanged);
 QA_DECLARE_TEST(passwordEntryOnChanged);
 QA_DECLARE_TEST(searchEntryOnChanged);
 QA_DECLARE_TEST(entryLongText);
+QA_DECLARE_TEST(entryOverflowText);
 
 QA_DECLARE_TEST(labelMultiLine);
 

--- a/test/qa/qa.h
+++ b/test/qa/qa.h
@@ -17,6 +17,7 @@ QA_DECLARE_TEST(checkboxOnToggled);
 QA_DECLARE_TEST(entryOnChanged);
 QA_DECLARE_TEST(passwordEntryOnChanged);
 QA_DECLARE_TEST(searchEntryOnChanged);
+QA_DECLARE_TEST(entryLongText);
 
 QA_DECLARE_TEST(labelMultiLine);
 

--- a/windows/entry.cpp
+++ b/windows/entry.cpp
@@ -68,7 +68,10 @@ void uiEntrySetText(uiEntry *e, const char *text)
 	e->inhibitChanged = TRUE;
 	uiWindowsSetWindowText(e->hwnd, text);
 	l = (int)strlen(text);
-	Edit_SetSel(e->hwnd, l, l);
+	// Only set the cursor if the entry has focus to avoid weird scrolling upon window
+	// creation. Cursor placement is otherwise determined by mouse position upon click.
+	if (GetFocus() == e->hwnd)
+		Edit_SetSel(e->hwnd, l, l);
 	e->inhibitChanged = FALSE;
 	// don't queue the control for resize; entry sizes are independent of their contents
 }


### PR DESCRIPTION
Fixes #232 

Long text entries display in a weirdly scrolled way on Windows upon first window creation. This is due to the cursor being placed at the end of the text but control dimension still being unknown.

Fix by placing the cursor only if the uiEntry has the focus as cursor placement is otherwise determined by the user upon clicking the control.

Verify: qa > uiEntry > 4. Entry Long Text

~~I would still hold off merging this until we can determine why the cursor position is being set in the first place (introduced in #102).~~
The only use case I can think of is when the `uiEntry` in question is already focused. @adamierymenko was this your original use case? Setting the text when the user is already editing the text within the control? If that is the case I will add another `qa` test.
Otherwise my cursor is always placed right under my mouse cursor once I click or at the end if the control is bigger (Windows 7 & wine 8.16).