### PR TITLE
doc: Clarify what the orientation means in uiSeparator.

### DIFF
--- a/ui.h
+++ b/ui.h
@@ -1308,7 +1308,7 @@ typedef struct uiSeparator uiSeparator;
 #define uiSeparator(this) ((uiSeparator *) (this))
 
 /**
- * Creates a new horizontal separator.
+ * Creates a new horizontal separator to separate controls being stacked vertically.
  *
  * @returns A new uiSeparator instance.
  * @memberof uiSeparator @static
@@ -1316,7 +1316,7 @@ typedef struct uiSeparator uiSeparator;
 _UI_EXTERN uiSeparator *uiNewHorizontalSeparator(void);
 
 /**
- * Creates a new vertical separator.
+ * Creates a new vertical separator to separate controls being stacked horizontally.
  *
  * @returns A new uiSeparator instance.
  * @memberof uiSeparator @static


### PR DESCRIPTION
Small fix to the docs as I've been bitten by this now, twice. The naming is not intuitive to me but ok, so be it.
Is it separating vertical/horizontal elements or drawing a vertical/horizontal line to separate? This patch should clarify that.

Interestingly enough using the wrong uiSeparator seemingly makes no difference on unix and windows but breaks the layout completely on darwin.