### PR TITLE
qa: Fix layout.

### DIFF
--- a/test/qa/qa.c
+++ b/test/qa/qa.c
@@ -3,11 +3,15 @@
 uiControl* qaMakeGuide(uiControl *c, const char *text)
 {
 	uiBox *hbox;
+	uiBox *vbox;
 	uiMultilineEntry *guide;
 
 	hbox = uiNewHorizontalBox();
 	uiBoxSetPadded(hbox, 1);
-	uiBoxAppend(hbox, c, 1);
+
+	vbox = uiNewVerticalBox();
+	uiBoxAppend(vbox, c, 0);
+	uiBoxAppend(hbox, uiControl(vbox), 1);
 
 	guide = uiNewMultilineEntry();
 	uiMultilineEntrySetText(guide, text);

--- a/test/qa/window.c
+++ b/test/qa/window.c
@@ -10,22 +10,11 @@ static int onClosing(uiWindow *w, void *data)
 static uiWindow* windowNew(uiControl *child, const char* (*guide)(void))
 {
 	uiWindow *w;
-	uiBox *box;
-	uiMultilineEntry *g;
-
-	box = uiNewHorizontalBox();
-
-	g = uiNewMultilineEntry();
-	uiMultilineEntrySetText(g, guide());
-	uiMultilineEntrySetReadOnly(g, 1);
-
-	uiBoxAppend(box, child, 1);
-	uiBoxAppend(box, uiControl(g), 1);
 
 	w = uiNewWindow("Quality Assurance", QA_WINDOW_WIDTH, QA_WINDOW_HEIGHT, 0);
 	uiWindowOnClosing(w, onClosing, NULL);
 
-	uiWindowSetChild(w, uiControl(box));
+	uiWindowSetChild(w, qaMakeGuide(child, guide()));
 	uiControlShow(uiControl(w));
 
 	return w;


### PR DESCRIPTION
Most of the tests had a strange layout up until now. See `qa > uiButton` for example, with the button either stretched (windows, unix) or weirdly in the center (darwin).
This was due to the controls being placed in a stretchy vbox. These two patches introduce another non stretchy sub-vbox and remove some code duplication while at it.

Unix before:
![image](https://github.com/libui-ng/libui-ng/assets/286606/41e45806-56d2-46db-86c5-7bd9fd915688)

Unix after:
![image](https://github.com/libui-ng/libui-ng/assets/286606/8ed5c069-585f-4125-8051-e1dca2ab7ecb)
