### PR TITLE
qa: Add manual test for uiSpinboxOnChanged().

### DIFF
--- a/test/qa/main.c
+++ b/test/qa/main.c
@@ -37,6 +37,11 @@ struct controlTestCase labelTestCases[] = {
 	{NULL, NULL, NULL}
 };
 
+struct controlTestCase spinboxTestCases[] = {
+	QA_TEST("1. Spinbox OnChanged Callback", spinboxOnChanged),
+	{NULL, NULL, NULL}
+};
+
 struct controlTestCase windowTestCases[] = {
 	QA_TEST("1. Fullscreen", windowFullscreen),
 	QA_TEST("2. Borderless", windowBorderless),
@@ -52,6 +57,7 @@ struct controlTestGroup controlTestGroups[] = {
 	{"uiCheckbox", checkboxTestCases},
 	{"uiEntry", entryTestCases},
 	{"uiLabel", labelTestCases},
+	{"uiSpinbox", spinboxTestCases},
 	{"uiWindow", windowTestCases},
 };
 

--- a/test/qa/meson.build
+++ b/test/qa/meson.build
@@ -5,6 +5,7 @@ libui_qa_sources = [
 	'checkbox.c',
 	'entry.c',
 	'label.c',
+	'spinbox.c',
 	'window.c',
 ]
 

--- a/test/qa/qa.h
+++ b/test/qa/qa.h
@@ -20,6 +20,8 @@ QA_DECLARE_TEST(searchEntryOnChanged);
 
 QA_DECLARE_TEST(labelMultiLine);
 
+QA_DECLARE_TEST(spinboxOnChanged);
+
 
 QA_DECLARE_TEST(windowFullscreen);
 QA_DECLARE_TEST(windowBorderless);

--- a/test/qa/spinbox.c
+++ b/test/qa/spinbox.c
@@ -1,0 +1,57 @@
+#include <stdio.h>
+
+#include "qa.h"
+
+static void spinboxOnChangedCb(uiSpinbox *c, void *data)
+{
+	char str[32];
+	uiLabel *label = data;
+	static int count = 0;
+
+	sprintf(str, "%d", ++count);
+	uiLabelSetText(label, str);
+}
+
+const char *spinboxOnChangedGuide() {
+	return
+	"1.\tYou should see a spinbox consisting of a text entry and two buttons.\n"
+	"\tThe number within the text entry should read `0` and the label\n"
+	"\tshould read `Changed count: 0`.\n"
+	"\n"
+	"2.\tClick the increase button (plus/arrow up).\n"
+	"\tThe number within the text entry should read `1` and the label\n"
+	"\tshould read `Changed count: 1`.\n"
+	"\n"
+	"2.\tClick the decrease button (minus/arrow down).\n"
+	"\tThe number within the text entry should read `0` and the label\n"
+	"\tshould read `Changed count: 2`.\n"
+	"\n"
+	"3.\tFocus the text entry, enter the number `5` and hit enter.\n"
+	"\tThe number within the text entry should read `5` and the label\n"
+	"\tshould read `Changed count: 3`.\n"
+	"\n"
+	;
+}
+
+uiControl* spinboxOnChanged()
+{
+	uiBox *hbox;
+	uiSpinbox *spinbox;
+	uiLabel *label;
+
+	hbox = uiNewHorizontalBox();
+	uiBoxSetPadded(hbox, 1);
+
+	spinbox = uiNewSpinbox(0, 10);
+	uiBoxAppend(hbox, uiControl(spinbox), 0);
+
+	label = uiNewLabel("Changed count:");
+	uiBoxAppend(hbox, uiControl(label), 0);
+
+	label = uiNewLabel("0");
+	uiBoxAppend(hbox, uiControl(label), 0);
+
+	uiSpinboxOnChanged(spinbox, spinboxOnChangedCb, label);
+
+	return uiControl(hbox);
+}


### PR DESCRIPTION
This is in preparation for the `uiDragDestination` PR that is still in the works, is massive, and that will require some refactoring for the some of the darwin components.
To make sure I don't break anything and to not blow up the `uiDragDestination` code even more, here one of the independent test cases.