### PR TITLE
qa: Add uiProgressBar tests and fix darwin.

### DIFF
--- a/darwin/progressbar.m
+++ b/darwin/progressbar.m
@@ -38,6 +38,10 @@ void uiProgressBarSetValue(uiProgressBar *p, int value)
 {
 	if (value == -1) {
 		[p->pi setIndeterminate:YES];
+		// Display to ensure a moving progress bar animation if a value
+		// has previously been set. Otherwise the bar will simply flash
+		// the last value.
+		[p->pi displayIfNeeded];
 		[p->pi startAnimation:p->pi];
 		return;
 	}

--- a/test/qa/main.c
+++ b/test/qa/main.c
@@ -37,6 +37,11 @@ struct controlTestCase labelTestCases[] = {
 	{NULL, NULL, NULL}
 };
 
+struct controlTestCase progressBarTestCases[] = {
+	QA_TEST("1. Progress Bar Values", progressBarValues),
+	{NULL, NULL, NULL}
+};
+
 struct controlTestCase windowTestCases[] = {
 	QA_TEST("1. Fullscreen", windowFullscreen),
 	QA_TEST("2. Borderless", windowBorderless),
@@ -52,6 +57,7 @@ struct controlTestGroup controlTestGroups[] = {
 	{"uiCheckbox", checkboxTestCases},
 	{"uiEntry", entryTestCases},
 	{"uiLabel", labelTestCases},
+	{"uiProgressBar", progressBarTestCases},
 	{"uiWindow", windowTestCases},
 };
 

--- a/test/qa/main.c
+++ b/test/qa/main.c
@@ -39,6 +39,7 @@ struct controlTestCase labelTestCases[] = {
 
 struct controlTestCase progressBarTestCases[] = {
 	QA_TEST("1. Progress Bar Values", progressBarValues),
+	QA_TEST("2. Progress Bar Indeterminate Start/Stop Animation", progressBarIndeterminate),
 	{NULL, NULL, NULL}
 };
 

--- a/test/qa/meson.build
+++ b/test/qa/meson.build
@@ -5,6 +5,7 @@ libui_qa_sources = [
 	'checkbox.c',
 	'entry.c',
 	'label.c',
+	'progressbar.c',
 	'window.c',
 ]
 

--- a/test/qa/progressbar.c
+++ b/test/qa/progressbar.c
@@ -43,3 +43,49 @@ uiControl* progressBarValues()
 	return uiControl(vbox);
 }
 
+static void indeterminateOnToggled(uiCheckbox *c, void *data)
+{
+	uiProgressBar *p = data;
+
+	if (uiCheckboxChecked(c))
+		uiProgressBarSetValue(p, -1);
+	else
+		uiProgressBarSetValue(p, 50);
+}
+
+const char *progressBarIndeterminateGuide() {
+	return
+	"1.\tYou should see a progress bar that visually indicates an\n"
+	"\tindeterminate progress level by showing a moving progress bar\n"
+	"\tanimation and a checked checkbox `Indeterminate`.\n"
+	"\n"
+	"2.\tUncheck the checkbox. The progress bar animation should stop and\n"
+	"\tdisplay a half full, solid bar.\n"
+	"\n"
+	"3.\tCheck the checkbox again. The progress bar animation should start\n"
+	"\tagain and visually suggest an indeterminate progress level by\n"
+	"\tshowing a moving progress bar.\n"
+	;
+}
+
+uiControl* progressBarIndeterminate()
+{
+	uiBox *vbox;
+	uiProgressBar *p;
+	uiCheckbox *c;
+
+	vbox = uiNewVerticalBox();
+	uiBoxSetPadded(vbox, 1);
+
+	p = uiNewProgressBar();
+	uiBoxAppend(vbox, uiControl(p), 0);
+
+	c = uiNewCheckbox("Indeterminate");
+	uiBoxAppend(vbox, uiControl(c), 0);
+	uiCheckboxOnToggled(c, indeterminateOnToggled, p);
+	uiCheckboxSetChecked(c, 1);
+	indeterminateOnToggled(c, p);
+
+	return uiControl(vbox);
+}
+

--- a/test/qa/progressbar.c
+++ b/test/qa/progressbar.c
@@ -1,0 +1,45 @@
+#include "qa.h"
+
+const char *progressBarValuesGuide() {
+	return
+	"1.\tYou should see 4 progress bars.\n"
+	"\n"
+	"2.\tThe first bar should be empty (or nearly empty on darwin) and\n"
+	"\tindicate a progress of `0%`\n"
+	"\n"
+	"3.\tThe second bar should be half way full and indicate a progress of\n"
+	"\t`50%`.\n"
+	"\n"
+	"4.\tThe third bar should be full and indicate a progress of `100%`.\n"
+	"\n"
+	"5.\tThe fourth bar should visually indicate an indeterminate progress\n"
+	"\tlevel by showing a moving progress bar animation.\n"
+	;
+}
+
+uiControl* progressBarValues()
+{
+	uiBox *vbox;
+	uiProgressBar *p;
+
+	vbox = uiNewVerticalBox();
+	uiBoxSetPadded(vbox, 1);
+
+	p = uiNewProgressBar();
+	uiBoxAppend(vbox, uiControl(p), 0);
+
+	p = uiNewProgressBar();
+	uiProgressBarSetValue(p, 50);
+	uiBoxAppend(vbox, uiControl(p), 0);
+
+	p = uiNewProgressBar();
+	uiProgressBarSetValue(p, 100);
+	uiBoxAppend(vbox, uiControl(p), 0);
+
+	p = uiNewProgressBar();
+	uiProgressBarSetValue(p, -1);
+	uiBoxAppend(vbox, uiControl(p), 0);
+
+	return uiControl(vbox);
+}
+

--- a/test/qa/qa.h
+++ b/test/qa/qa.h
@@ -20,6 +20,7 @@ QA_DECLARE_TEST(searchEntryOnChanged);
 
 QA_DECLARE_TEST(labelMultiLine);
 
+QA_DECLARE_TEST(progressBarValues);
 
 QA_DECLARE_TEST(windowFullscreen);
 QA_DECLARE_TEST(windowBorderless);

--- a/test/qa/qa.h
+++ b/test/qa/qa.h
@@ -21,6 +21,7 @@ QA_DECLARE_TEST(searchEntryOnChanged);
 QA_DECLARE_TEST(labelMultiLine);
 
 QA_DECLARE_TEST(progressBarValues);
+QA_DECLARE_TEST(progressBarIndeterminate);
 
 QA_DECLARE_TEST(windowFullscreen);
 QA_DECLARE_TEST(windowBorderless);


### PR DESCRIPTION
Two visual tests for uiProgressBar.

The second one fails on my system: macOS 11.7 (Big Sur) . Setting `-1` after previously having set some other value will not return to the expected animation on.
The third patch in this series fixes this by calling `[p->pi displayIfNeeded];` .
Another thing that seems to work is calling `[p->pi setUsesThreadedAnimation:NO];` and `[p->pi setUsesThreadedAnimation:YES];` but I found this to be cleaner.

Another possible issue that `qa > uiProgressBar > 2.` highlights is the delay when setting a value on darwin whilst the progress bar is animating.
I was able to get an instant set by encapsulating the `setIndeterminate` call. Happy to include that in this patch set.
```
[p->pi setUsesThreadedAnimation:NO];
[p->pi setIndeterminate:NO];
[p->pi setUsesThreadedAnimation:YES];
```