### PR TITLE
Add manual tests for uiRadioButtonsOnSelected() and fix darwin and windows.

### DIFF
--- a/darwin/radiobuttons.m
+++ b/darwin/radiobuttons.m
@@ -25,6 +25,7 @@ struct uiRadioButtons {
 	radioButtonsDelegate *delegate;
 	void (*onSelected)(uiRadioButtons *, void *);
 	void *onSelectedData;
+	int selected;
 };
 
 @implementation radioButtonsDelegate
@@ -39,8 +40,15 @@ struct uiRadioButtons {
 
 - (IBAction)onClicked:(id)sender
 {
+	NSButton *b = (NSButton *)sender;
 	uiRadioButtons *r = self->libui_r;
+	NSInteger index;
 
+	index = [r->buttons indexOfObject:b];
+	if (index == r->selected)
+		return;
+
+	r->selected = index;
 	(*(r->onSelected))(r, r->onSelectedData);
 }
 
@@ -156,21 +164,15 @@ void uiRadioButtonsAppend(uiRadioButtons *r, const char *text)
 
 int uiRadioButtonsSelected(uiRadioButtons *r)
 {
-	NSButton *b;
-	NSUInteger i;
-
-	for (i = 0; i < [r->buttons count]; i++) {
-		b = (NSButton *) [r->buttons objectAtIndex:i];
-		if ([b state] == NSOnState)
-			return i;
-	}
-	return -1;
+	return r->selected;
 }
 
 void uiRadioButtonsSetSelected(uiRadioButtons *r, int n)
 {
 	NSButton *b;
 	NSInteger state;
+
+	r->selected = n;
 
 	state = NSOnState;
 	if (n == -1) {
@@ -198,6 +200,7 @@ uiRadioButtons *uiNewRadioButtons(void)
 	r->view = [[NSView alloc] initWithFrame:NSZeroRect];
 	r->buttons = [NSMutableArray new];
 	r->constraints = [NSMutableArray new];
+	r->selected = -1;
 
 	r->delegate = [[radioButtonsDelegate alloc] initWithR:r];
 

--- a/test/qa/main.c
+++ b/test/qa/main.c
@@ -37,6 +37,11 @@ struct controlTestCase labelTestCases[] = {
 	{NULL, NULL, NULL}
 };
 
+struct controlTestCase radioButtonsTestCases[] = {
+	QA_TEST("1. OnSelected Callback", radioButtonsOnSelected),
+	{NULL, NULL, NULL}
+};
+
 struct controlTestCase windowTestCases[] = {
 	QA_TEST("1. Fullscreen", windowFullscreen),
 	QA_TEST("2. Borderless", windowBorderless),
@@ -52,6 +57,7 @@ struct controlTestGroup controlTestGroups[] = {
 	{"uiCheckbox", checkboxTestCases},
 	{"uiEntry", entryTestCases},
 	{"uiLabel", labelTestCases},
+	{"uiRadioButtons", radioButtonsTestCases},
 	{"uiWindow", windowTestCases},
 };
 

--- a/test/qa/meson.build
+++ b/test/qa/meson.build
@@ -5,6 +5,7 @@ libui_qa_sources = [
 	'checkbox.c',
 	'entry.c',
 	'label.c',
+	'radiobuttons.c',
 	'window.c',
 ]
 

--- a/test/qa/qa.h
+++ b/test/qa/qa.h
@@ -20,6 +20,7 @@ QA_DECLARE_TEST(searchEntryOnChanged);
 
 QA_DECLARE_TEST(labelMultiLine);
 
+QA_DECLARE_TEST(radioButtonsOnSelected);
 
 QA_DECLARE_TEST(windowFullscreen);
 QA_DECLARE_TEST(windowBorderless);

--- a/test/qa/radiobuttons.c
+++ b/test/qa/radiobuttons.c
@@ -1,0 +1,55 @@
+#include <stdio.h>
+
+#include "qa.h"
+
+static void radioButtonsOnSelectedCb(uiRadioButtons *r, void *data)
+{
+	char str[32];
+	static int count = 0;
+	uiLabel *label = data;
+
+	sprintf(str, "%d", ++count);
+	uiLabelSetText(label, str);
+}
+
+const char *radioButtonsOnSelectedGuide() {
+	return
+	"1.\tYou should see two radio buttons `Item 1` and `Item 2` as well as\n"
+	"\ta label displaying `Selected count: 0`. None of the radio buttons\n"
+	"\tshould be selected.\n"
+	"\n"
+	"2.\tClick the radio button `Item 1`. This should select the radio button\n"
+	"\t`Item 1` and the label should read `Selected count: 1`.\n"
+	"\n"
+	"2.\tClick the radio button `Item 1` again. Nothing should happen.\n"
+	"\n"
+	"2.\tClick the radio button `Item 2`. This should select the radio button\n"
+	"\t`Item 2`, deselect the radio button `Item 1`  and the label should now\n"
+	"\tread `Selected count: 2`.\n"
+	;
+}
+
+uiControl* radioButtonsOnSelected()
+{
+	uiBox *hbox;
+	uiRadioButtons *r;
+	uiLabel *label;
+
+	hbox = uiNewHorizontalBox();
+	uiBoxSetPadded(hbox, 1);
+
+	r = uiNewRadioButtons();
+	uiBoxAppend(hbox, uiControl(r), 0);
+	uiRadioButtonsAppend(r, "Item 1");
+	uiRadioButtonsAppend(r, "Item 2");
+
+	label = uiNewLabel("Selected count:");
+	uiBoxAppend(hbox, uiControl(label), 0);
+
+	label = uiNewLabel("0");
+	uiBoxAppend(hbox, uiControl(label), 0);
+
+	uiRadioButtonsOnSelected(r, radioButtonsOnSelectedCb, label);
+
+	return uiControl(hbox);
+}

--- a/windows/radiobuttons.cpp
+++ b/windows/radiobuttons.cpp
@@ -23,14 +23,18 @@ static BOOL onWM_COMMAND(uiControl *c, HWND clicked, WORD code, LRESULT *lResult
 
 	if (code != BN_CLICKED)
 		return FALSE;
+
+	*lResult = 0;
 	for (const HWND &hwnd : *(r->hwnds)) {
 		check = BST_UNCHECKED;
-		if (clicked == hwnd)
+		if (clicked == hwnd) {
+			if (Button_GetCheck(hwnd) == BST_CHECKED)
+				return TRUE;
 			check = BST_CHECKED;
+		}
 		SendMessage(hwnd, BM_SETCHECK, check, 0);
 	}
 	(*(r->onSelected))(r, r->onSelectedData);
-	*lResult = 0;
 	return TRUE;
 }
 


### PR DESCRIPTION
Add manual tests for uiRadioButtonsOnSelected()  as we can currently not do so via unit tests.

Fix both darwin and windows that will trigger the `uiRadioButtonsOnSelected()` callback on element that are already selected. This matches the behavior of other controls within the library and is the default behavior on unix.

Fixes #240 

Looking at this test on darwin does give me the impression that something in the layout translation (autolayout to uiBox) is severely broken. Related to #216 