### PR TITLE
Clean up examples by using global includes and remove dates.

### DIFF
--- a/examples/controlgallery/main.c
+++ b/examples/controlgallery/main.c
@@ -1,7 +1,6 @@
-// 2 september 2015
 #include <stdio.h>
 #include <string.h>
-#include "../../ui.h"
+#include <ui.h>
 
 static int onClosing(uiWindow *w, void *data)
 {

--- a/examples/cpp-multithread/main.cpp
+++ b/examples/cpp-multithread/main.cpp
@@ -1,4 +1,3 @@
-// 6 december 2015
 #include <thread>
 #include <chrono>
 #include <mutex>
@@ -6,7 +5,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
-#include "../../ui.h"
+#include <ui.h>
 using namespace std;
 
 uiMultilineEntry *e;

--- a/examples/datetime/main.c
+++ b/examples/datetime/main.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include "../../ui.h"
+#include <ui.h>
 
 uiDateTimePicker *dtboth, *dtdate, *dttime;
 

--- a/examples/drawtext/main.c
+++ b/examples/drawtext/main.c
@@ -1,7 +1,6 @@
-// 10 march 2018
 #include <stdio.h>
 #include <string.h>
-#include "../../ui.h"
+#include <ui.h>
 
 uiWindow *mainwin;
 uiArea *area;

--- a/examples/histogram/main.c
+++ b/examples/histogram/main.c
@@ -1,9 +1,8 @@
-// 13 october 2015
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
-#include "../../ui.h"
+#include <ui.h>
 
 uiWindow *mainwin;
 uiArea *histogram;

--- a/examples/timer/main.c
+++ b/examples/timer/main.c
@@ -1,7 +1,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
-#include "../../ui.h"
+#include <ui.h>
 
 uiMultilineEntry *e;
 


### PR DESCRIPTION
The examples should reflect external use and hence use `#include <ui.h>`.
Remove the visual clutter of the data comments while at it as well.