### PR TITLE
ci: Install meson and ninja using apt instead of pip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,8 @@ jobs:
     steps:
       - name: Install Meson and Linux Deps
         run: |
-          python3 -m pip install --upgrade pip setuptools wheel
-          pip3 install meson ninja
           sudo apt-get update -y
-          sudo apt-get install -y libgtk-3-dev xvfb
+          sudo apt-get install -y libgtk-3-dev meson ninja-build xvfb
       - name: Checkout
         uses: actions/checkout@v3
       - name: Meson Setup Build


### PR DESCRIPTION
Hi!
I noticed that recently, there is no longer a need for a workaround to install meson and ninja using pip instead of apt on  Ubuntu. (My understanding is that pip was used because the latest meson and ninja were not available in APT. Sorry if I am wrong.)