### PR TITLE
onFree callback for uiControl instances

### DIFF
--- a/common/control.c
+++ b/common/control.c
@@ -74,6 +74,11 @@ void uiFreeControl(uiControl *c)
 {
 	if (uiControlParent(c) != NULL)
 		uiprivUserBug("You cannot destroy a uiControl while it still has a parent. (control: %p)", c);
+
+	if (c->onFree) {
+		(*(c->onFree))(c, c->onFreeData);
+	}
+
 	uiprivFree(c);
 }
 
@@ -98,4 +103,10 @@ int uiControlEnabledToUser(uiControl *c)
 		c = uiControlParent(c);
 	}
 	return 1;
+}
+
+void uiControlOnFree(uiControl *w, void (*f)(uiControl *, void *senderData), void *data)
+{
+	w->onFree = f;
+	w->onFreeData = data;
 }

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -32,10 +32,18 @@ int unitTestSetup(void **_state)
 	return 0;
 }
 
+void unitControlOnFree(uiControl *c, void *data)
+{
+	assert_non_null(c);
+	assert_non_null(data);
+	assert_ptr_equal(c, ((struct state *)data)->w);
+}
+
 int unitTestTeardown(void **_state)
 {
 	struct state *state = *_state;
 
+	uiControlOnFree(uiControl(state->w), unitControlOnFree, state);
 	uiWindowSetChild(state->w, uiControl(state->c));
 	uiControlShow(uiControl(state->w));
 	//uiMain();

--- a/ui.h
+++ b/ui.h
@@ -116,6 +116,9 @@ struct uiControl {
 	int (*Enabled)(uiControl *);
 	void (*Enable)(uiControl *);
 	void (*Disable)(uiControl *);
+
+	void (*onFree)(uiControl *, void *);
+	void *onFreeData;
 };
 // TOOD add argument names to all arguments
 #define uiControl(this) ((uiControl *) (this))
@@ -222,6 +225,20 @@ _UI_EXTERN void uiControlEnable(uiControl *c);
  * @memberof uiControl
  */
 _UI_EXTERN void uiControlDisable(uiControl *c);
+
+/**
+ * Registers a callback for when the control is about to be freed.
+ *
+ * @param c uiControl instance.
+ * @param f Callback function.\n
+ *          @p sender Back reference to the instance that triggered the callback.\n
+ *          @p senderData User data registered with the sender instance.\n
+ * @param data User data to be passed to the callback.
+ *
+ * @note Only one callback can be registered at a time.
+ * @memberof uiControl
+ */
+_UI_EXTERN void uiControlOnFree(uiControl *w, void (*f)(uiControl *sender, void *senderData), void *data);
 
 /**
  * Allocates a uiControl.


### PR DESCRIPTION
This pull request concerns the destroying of UI controls, the issue being some controls could be destroyed outside of the purview of the embedding application, possibly leading to memory safety issues. In order to keep the implementing application aware of controls' lifecycle/status, the PR implements an `onFree` callback for `uiControl` structures (and its corresponding context as `onFreeData`).

This topic was originally discussed [here](https://github.com/libui-ng/libui-ng/pull/220#issue-1889287906).