### PR TITLE
WIP Tooltips

### DIFF
--- a/darwin/meson.build
+++ b/darwin/meson.build
@@ -46,6 +46,7 @@ libui_sources += [
 	'darwin/table.m',
 	'darwin/tablecolumn.m',
 	'darwin/text.m',
+	'darwin/tooltip.m',
 	'darwin/undocumented.m',
 	'darwin/util.m',
 	'darwin/window.m',

--- a/darwin/tooltip.m
+++ b/darwin/tooltip.m
@@ -1,0 +1,12 @@
+#include "uipriv_darwin.h"
+
+// https://developer.apple.com/documentation/appkit/nsview/1483541-tooltip?language=objc
+
+void uiControlSetTooltip(uiControl *c, const char *tooltip) {
+    NSView *view = (NSView *)uiControlHandle(c);
+	if (tooltip == NULL) {
+		view.toolTip = nil;
+	} else {
+	    view.toolTip = uiprivToNSString(text);
+	}
+}

--- a/ui.h
+++ b/ui.h
@@ -4008,6 +4008,18 @@ _UI_EXTERN void uiTableSetSelection(uiTable *t, uiTableSelection *sel);
  */
 _UI_EXTERN void uiFreeTableSelection(uiTableSelection* s);
 
+/**
+ * Sets the control tooltip.
+ *
+ * @param c uiControl instance.
+ * @param tooltip Control tooltip.\n
+ *             A valid, `NULL` terminated UTF-8 string.\n
+ *             Data is copied internally. Ownership is not transferred.
+ * @note Setting `NULL` resets the tooltip to the default value.
+ * @memberof uiControl
+ */
+_UI_EXTERN void uiControlSetTooltip(uiControl *c, const char *tooltip);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ui_windows.h
+++ b/ui_windows.h
@@ -20,6 +20,7 @@ struct uiWindowsControl {
 	// TODO this should be int on both os x and windows
 	BOOL enabled;
 	BOOL visible;
+	void *tooltip;
 	void (*SyncEnableState)(uiWindowsControl *, int);
 	void (*SetParentHWND)(uiWindowsControl *, HWND);
 	void (*MinimumSize)(uiWindowsControl *, int *, int *);
@@ -185,7 +186,9 @@ _UI_EXTERN void uiWindowsControlChildVisibilityChanged(uiWindowsControl *);
 	uiWindowsControl(var)->AssignControlIDZOrder = type ## AssignControlIDZOrder; \
 	uiWindowsControl(var)->ChildVisibilityChanged = type ## ChildVisibilityChanged; \
 	uiWindowsControl(var)->visible = 1; \
-	uiWindowsControl(var)->enabled = 1;
+	uiWindowsControl(var)->enabled = 1; \
+	uiWindowsControl(var)->tooltip = NULL;
+
 // TODO document
 _UI_EXTERN uiWindowsControl *uiWindowsAllocControl(size_t n, uint32_t typesig, const char *typenamestr);
 

--- a/unix/meson.build
+++ b/unix/meson.build
@@ -43,6 +43,7 @@ libui_sources += [
 	'unix/table.c',
 	'unix/tablemodel.c',
 	'unix/text.c',
+	'unix/tooltip.c',
 	'unix/util.c',
 	'unix/window.c',
 ]

--- a/unix/tooltip.c
+++ b/unix/tooltip.c
@@ -1,0 +1,9 @@
+#include "uipriv_unix.h"
+
+void uiControlSetTooltip(uiControl *c, const char *text) {
+	if (text == NULL) {
+		gtk_widget_set_has_tooltip(GTK_WIDGET(uiControlHandle(c)), FALSE);
+	} else {
+		gtk_widget_set_tooltip_text(GTK_WIDGET(uiControlHandle(c)), text);
+	}
+}

--- a/windows/meson.build
+++ b/windows/meson.build
@@ -59,6 +59,7 @@ libui_sources += [
 	'windows/tablemetrics.cpp',
 	'windows/tabpage.cpp',
 	'windows/text.cpp',
+	'windows/tooltip.cpp',
 	'windows/utf16.cpp',
 	'windows/utilwin.cpp',
 	'windows/window.cpp',

--- a/windows/tooltip.cpp
+++ b/windows/tooltip.cpp
@@ -1,0 +1,45 @@
+#include "uipriv_windows.hpp"
+
+static void *CreateTooltip(HWND hparent, const wchar_t* text) {
+    HWND hwndTT = CreateWindowEx(WS_EX_TOPMOST, TOOLTIPS_CLASS, NULL,
+        WS_POPUP | TTS_NOPREFIX | TTS_ALWAYSTIP,
+        CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+        hparent, NULL, hInstance, NULL);
+
+    if (!hwndTT) {
+        printf("ERROR: Failed to create tooltip window.");
+        return NULL;
+    }
+
+    SetWindowPos(hwndTT, HWND_TOPMOST, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+
+    TTTOOLINFO ti = { 0 };
+    ti.cbSize = sizeof(ti);
+    ti.uFlags = TTF_SUBCLASS;
+    ti.hwnd = hparent;
+    ti.hinst = hInstance;
+    ti.lpszText = (LPWSTR)text;
+    GetClientRect(hparent, &ti.rect);
+    ti.rect.right = 400;
+
+    if (!SendMessage(hwndTT, TTM_ADDTOOL, 0, (LPARAM)&ti)) {
+        logLastError(L"Failed to set rect to tooltip window.");
+        uiWindowsEnsureDestroyWindow(hwndTT);
+        return NULL;
+    }
+    return hwndTT;
+}
+
+void uiControlSetTooltip(uiControl *c, const char *tooltip) {
+	if (tooltip == NULL) {
+		if (uiWindowsControl(c)->tooltip == NULL) return;
+		uiWindowsEnsureDestroyWindow((HWND)uiWindowsControl(c)->tooltip);
+		return;
+	}
+    wchar_t *wtext = toUTF16(tooltip);
+    void *ptr = CreateTooltip((HWND)uiControlHandle(c), wtext);
+    uiprivFree(wtext);
+
+	uiWindowsControl(c)->tooltip = ptr;
+}


### PR DESCRIPTION
Adapted from https://github.com/libui-ng/libui-ng/commit/b65e161f941252a1f49ce385987792ddf2268637

Implements
```
/**
 * Sets the control tooltip.
 *
 * @param c uiControl instance.
 * @param tooltip Control tooltip.\n
 *             A valid, `NULL` terminated UTF-8 string.\n
 *             Data is copied internally. Ownership is not transferred.
 * @note Setting `NULL` resets the tooltip to the default value.
 * @memberof uiControl
 */
_UI_EXTERN void uiControlSetTooltip(uiControl *c, const char *tooltip);
```
Tested only on GTK3 and WinForms. I tested only on buttons. I might write some tests to make sure it works on other widgets.