### PR TITLE
uiWindow unit tests and fixes for unix

### DIFF
--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -27,6 +27,7 @@ int unitTestSetup(void **_state)
 	uiInitOptions o = {0};
 
 	assert_null(uiInit(&o));
+	state->c = NULL;
 	state->w = uiNewWindow(UNIT_TEST_WINDOW_TITLE, UNIT_TEST_WINDOW_WIDTH, UNIT_TEST_WINDOW_HEIGHT, 0);
 	uiWindowOnClosing(state->w, unitWindowOnClosingQuit, NULL);
 	return 0;
@@ -36,7 +37,8 @@ int unitTestTeardown(void **_state)
 {
 	struct state *state = *_state;
 
-	uiWindowSetChild(state->w, uiControl(state->c));
+	if (state->c != NULL)
+		uiWindowSetChild(state->w, uiControl(state->c));
 	uiControlShow(uiControl(state->w));
 	//uiMain();
 	uiMainSteps();

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -59,6 +59,7 @@ int main(void)
 	int failedComponents = 0;
 	struct unitTest unitTests[] = {
 		{ initRunUnitTests },
+		{ windowRunUnitTests },
 		{ menuRunUnitTests },
 		{ sliderRunUnitTests },
 		{ spinboxRunUnitTests },

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -27,7 +27,7 @@ int unitTestSetup(void **_state)
 	uiInitOptions o = {0};
 
 	assert_null(uiInit(&o));
-	state->w = uiNewWindow("Unit Test", UNIT_TEST_WINDOW_WIDTH, UNIT_TEST_WINDOW_HEIGHT, 0);
+	state->w = uiNewWindow(UNIT_TEST_WINDOW_TITLE, UNIT_TEST_WINDOW_WIDTH, UNIT_TEST_WINDOW_HEIGHT, 0);
 	uiWindowOnClosing(state->w, unitWindowOnClosingQuit, NULL);
 	return 0;
 }

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -14,6 +14,7 @@ libui_unit_sources = [
         'entry.c',
         'menu.c',
         'progressbar.c',
+        'window.c',
 ]
 
 if libui_OS == 'windows'

--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -14,6 +14,7 @@
  * Unit test run functions.
  */
 int initRunUnitTests(void);
+int windowRunUnitTests(void);
 int sliderRunUnitTests(void);
 int spinboxRunUnitTests(void);
 int labelRunUnitTests(void);

--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -37,6 +37,7 @@ int unitWindowOnClosingQuit(uiWindow *w, void *data);
 
 #define UNIT_TEST_WINDOW_WIDTH 300
 #define UNIT_TEST_WINDOW_HEIGHT 200
+#define UNIT_TEST_WINDOW_TITLE "Unit Test"
 
 /**
  * Helper for setting up the state variable used in unit tests.

--- a/test/unit/window.c
+++ b/test/unit/window.c
@@ -19,6 +19,24 @@ static void windowNew(void **state)
 	uiUninit();
 }
 
+static void windowDefaultMargined(void **state)
+{
+	uiWindow *w = uiWindowFromState(state);
+
+	assert_int_equal(uiWindowMargined(w), 0);
+}
+
+static void windowMargined(void **state)
+{
+	uiWindow *w = uiWindowFromState(state);
+
+	uiWindowSetMargined(w, 1);
+	assert_int_equal(uiWindowMargined(w), 1);
+
+	uiWindowSetMargined(w, 0);
+	assert_int_equal(uiWindowMargined(w), 0);
+}
+
 static void windowDefaultTitle(void **state)
 {
 	uiWindow *w = uiWindowFromState(state);
@@ -79,6 +97,26 @@ static void windowSetContentSize(void **state)
 	assert_int_equal(height, UNIT_TEST_WINDOW_HEIGHT + 10);
 }
 
+static void windowMarginedSetContentSize(void **state)
+{
+	uiWindow *w = uiWindowFromState(state);
+	int width, height;
+
+	uiWindowSetMargined(w, 0);
+	uiWindowSetContentSize(w, UNIT_TEST_WINDOW_WIDTH + 10, UNIT_TEST_WINDOW_HEIGHT + 10);
+
+	uiWindowContentSize(w, &width, &height);
+	assert_int_equal(width, UNIT_TEST_WINDOW_WIDTH + 10);
+	assert_int_equal(height, UNIT_TEST_WINDOW_HEIGHT + 10);
+
+	uiWindowSetMargined(w, 1);
+	uiWindowSetContentSize(w, UNIT_TEST_WINDOW_WIDTH + 10, UNIT_TEST_WINDOW_HEIGHT + 10);
+
+	uiWindowContentSize(w, &width, &height);
+	assert_int_equal(width, UNIT_TEST_WINDOW_WIDTH + 10);
+	assert_int_equal(height, UNIT_TEST_WINDOW_HEIGHT + 10);
+}
+
 void onContentSizeChangedNoCall(uiWindow *w, void *data)
 {
 	function_called();
@@ -118,11 +156,14 @@ int windowRunUnitTests(void)
 {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(windowNew),
+		windowUnitTest(windowDefaultMargined),
+		windowUnitTest(windowMargined),
 		windowUnitTest(windowDefaultTitle),
 		windowUnitTest(windowDefaultContentSize),
 		windowUnitTest(windowSetTitle),
 		windowUnitTest(windowSetPosition),
 		windowUnitTest(windowSetContentSize),
+		windowUnitTest(windowMarginedSetContentSize),
 		windowUnitTest(windowSetContentSizeNoCallback),
 		windowUnitTest(windowSetPositionNoCallback),
 	};

--- a/test/unit/window.c
+++ b/test/unit/window.c
@@ -1,0 +1,132 @@
+#include "unit.h"
+
+#define uiWindowFromState(s) (((struct state *)*(s))->w)
+
+static void windowNew(void **state)
+{
+	uiInitOptions o = {0};
+	uiWindow *w;
+
+	assert_null(uiInit(&o));
+	w = uiNewWindow(UNIT_TEST_WINDOW_TITLE, UNIT_TEST_WINDOW_WIDTH, UNIT_TEST_WINDOW_HEIGHT, 0);
+	uiWindowOnClosing(w, unitWindowOnClosingQuit, NULL);
+	uiControlShow(uiControl(w));
+
+	//uiMain();
+	uiMainSteps();
+	uiMainStep(1);
+	uiControlDestroy(uiControl(w));
+	uiUninit();
+}
+
+static void windowDefaultTitle(void **state)
+{
+	uiWindow *w = uiWindowFromState(state);
+	char *rv;
+
+	rv = uiWindowTitle(w);
+	assert_string_equal(rv, UNIT_TEST_WINDOW_TITLE);
+	uiFreeText(rv);
+}
+
+static void windowSetTitle(void **state)
+{
+	uiWindow *w = uiWindowFromState(state);
+	const char *text = "SetTitle";
+	char *rv;
+
+	uiWindowSetTitle(w, text);
+	rv = uiWindowTitle(w);
+	assert_string_equal(rv, text);
+	uiFreeText(rv);
+}
+
+static void windowDefaultContentSize(void **state)
+{
+	uiWindow *w = uiWindowFromState(state);
+	int width, height;
+
+	uiWindowContentSize(w, &width, &height);
+	assert_int_equal(width, UNIT_TEST_WINDOW_WIDTH);
+	assert_int_equal(height, UNIT_TEST_WINDOW_HEIGHT);
+}
+
+static void windowSetPosition(void **state)
+{
+	uiWindow *w = uiWindowFromState(state);
+	int x, y;
+
+	uiWindowSetPosition(w, 0, 0);
+	uiWindowPosition(w, &x, &y);
+	assert_int_equal(x, 0);
+	assert_int_equal(y, 0);
+
+	uiWindowSetPosition(w, 1, 1);
+	uiWindowPosition(w, &x, &y);
+	assert_int_equal(x, 1);
+	assert_int_equal(y, 1);
+}
+
+static void windowSetContentSize(void **state)
+{
+	uiWindow *w = uiWindowFromState(state);
+	int width, height;
+
+	uiWindowSetContentSize(w, UNIT_TEST_WINDOW_WIDTH + 10, UNIT_TEST_WINDOW_HEIGHT + 10);
+
+	uiWindowContentSize(w, &width, &height);
+	assert_int_equal(width, UNIT_TEST_WINDOW_WIDTH + 10);
+	assert_int_equal(height, UNIT_TEST_WINDOW_HEIGHT + 10);
+}
+
+void onContentSizeChangedNoCall(uiWindow *w, void *data)
+{
+	function_called();
+}
+
+static void windowSetContentSizeNoCallback(void **state)
+{
+	uiWindow *w = uiWindowFromState(state);
+
+	uiWindowOnContentSizeChanged(w, onContentSizeChangedNoCall, NULL);
+	// FIXME: https://gitlab.com/cmocka/cmocka/-/issues/18
+	//expect_function_calls(onContentSizeChangedNoCall, 0);
+	uiWindowSetContentSize(w, UNIT_TEST_WINDOW_WIDTH + 10, UNIT_TEST_WINDOW_HEIGHT + 10);
+	uiWindowSetContentSize(w, UNIT_TEST_WINDOW_WIDTH + 20, UNIT_TEST_WINDOW_HEIGHT + 20);
+}
+
+void onPositionChangedCallback(uiWindow *w, void *data)
+{
+	function_called();
+}
+
+static void windowSetPositionNoCallback(void **state)
+{
+	uiWindow *w = uiWindowFromState(state);
+
+	uiWindowOnContentSizeChanged(w, onPositionChangedCallback, NULL);
+	// FIXME: https://gitlab.com/cmocka/cmocka/-/issues/18
+	//expect_function_calls(onPositionChangedCallback, 0);
+	uiWindowSetPosition(w, 0, 0);
+	uiWindowSetPosition(w, 1, 1);
+}
+
+#define windowUnitTest(f) cmocka_unit_test_setup_teardown((f), \
+		unitTestSetup, unitTestTeardown)
+
+int windowRunUnitTests(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(windowNew),
+		windowUnitTest(windowDefaultTitle),
+		windowUnitTest(windowDefaultContentSize),
+		windowUnitTest(windowSetTitle),
+		windowUnitTest(windowSetPosition),
+		windowUnitTest(windowSetContentSize),
+		windowUnitTest(windowSetContentSizeNoCallback),
+		windowUnitTest(windowSetPositionNoCallback),
+	};
+
+	return cmocka_run_group_tests_name("uiWindow", tests, unitTestsSetup, unitTestsTeardown);
+}
+

--- a/ui.h
+++ b/ui.h
@@ -487,7 +487,7 @@ _UI_EXTERN void uiWindowSetChild(uiWindow *w, uiControl *child);
  * Returns whether or not the window has a margin.
  *
  * @param w uiWindow instance.
- * @returns `TRUE` if window has a margin, `FALSE` otherwise. [Default: `TODO`]
+ * @returns `TRUE` if window has a margin, `FALSE` otherwise. [Default: `FALSE`]
  * @memberof uiWindow
  */
 _UI_EXTERN int uiWindowMargined(uiWindow *w);

--- a/unix/main.c
+++ b/unix/main.c
@@ -19,6 +19,10 @@ const char *uiInit(uiInitOptions *o)
 	uiprivInitAlloc();
 	uiprivLoadFutures();
 	timers = g_hash_table_new(g_direct_hash, g_direct_equal);
+
+	// Run the event loop manually by default to ensure we can run uiMainStep()
+	// internally to make asynchronous GTK calls appear synchronous.
+	uiMainSteps();
 	return NULL;
 }
 

--- a/unix/window.c
+++ b/unix/window.c
@@ -393,6 +393,10 @@ uiWindow *uiNewWindow(const char *title, int width, int height, int hasMenubar)
 	// show everything in the vbox, but not the GtkWindow itself
 	gtk_widget_show_all(w->vboxWidget);
 
+	// create resources to return the correct content size after creation
+	// but before display
+	gtk_widget_realize(w->widget);
+
 	// and connect our events
 	g_signal_connect(w->widget, "delete-event", G_CALLBACK(onClosing), w);
 	g_signal_connect(w->childHolderWidget, "size-allocate", G_CALLBACK(onSizeAllocate), w);

--- a/unix/window.c
+++ b/unix/window.c
@@ -217,11 +217,7 @@ void uiWindowOnPositionChanged(uiWindow *w, void (*f)(uiWindow *, void *), void 
 
 void uiWindowContentSize(uiWindow *w, int *width, int *height)
 {
-	GtkAllocation allocation;
-
-	gtk_widget_get_allocation(w->childHolderWidget, &allocation);
-	*width = allocation.width;
-	*height = allocation.height;
+	gtk_window_get_size(w->window, width, height);
 }
 
 void uiWindowSetContentSize(uiWindow *w, int width, int height)

--- a/unix/window.c
+++ b/unix/window.c
@@ -222,33 +222,8 @@ void uiWindowContentSize(uiWindow *w, int *width, int *height)
 
 void uiWindowSetContentSize(uiWindow *w, int width, int height)
 {
-	GtkAllocation childAlloc;
-	gint winWidth, winHeight;
-
-	// we need to resize the child holder widget to the given size
-	// we can't resize that without running the event loop
-	// but we can do gtk_window_set_size()
-	// so how do we deal with the differences in sizes?
-	// simple arithmetic, of course!
-
-	// from what I can tell, the return from gtk_widget_get_allocation(w->window) and gtk_window_get_size(w->window) will be the same
-	// this is not affected by Wayland and not affected by GTK+ builtin CSD
-	// so we can safely juse use them to get the real window size!
-	// since we're using gtk_window_resize(), use the latter
-	gtk_window_get_size(w->window, &winWidth, &winHeight);
-
-	// now get the child holder widget's current allocation
-	gtk_widget_get_allocation(w->childHolderWidget, &childAlloc);
-	// and punch that out of the window size
-	winWidth -= childAlloc.width;
-	winHeight -= childAlloc.height;
-
-	// now we just need to add the new size back in
-	winWidth += width;
-	winHeight += height;
-
 	w->changingSize = TRUE;
-	gtk_window_resize(w->window, winWidth, winHeight);
+	gtk_window_resize(w->window, width, height);
 	// gtk_window_resize() is asynchronous. Run the event loop manually.
 	while (gtk_events_pending())
 		if (!uiMainStep(1))

--- a/unix/window.c
+++ b/unix/window.c
@@ -199,10 +199,14 @@ void uiWindowSetPosition(uiWindow *w, int x, int y)
 {
 	w->changingPosition = TRUE;
 	gtk_window_move(w->window, x, y);
-	// gtk_window_move() is asynchronous. Wait for the configure-event
-	while (w->changingPosition)
+	// gtk_window_move() is asynchronous. Run the event loop manually.
+	while (gtk_events_pending())
 		if (!uiMainStep(1))
 			break;
+
+	// Hidden windows do not trigger the "configure-event".
+	// TODO log failure for visible windows.
+	w->changingPosition = FALSE;
 }
 
 void uiWindowOnPositionChanged(uiWindow *w, void (*f)(uiWindow *, void *), void *data)

--- a/unix/window.c
+++ b/unix/window.c
@@ -253,10 +253,14 @@ void uiWindowSetContentSize(uiWindow *w, int width, int height)
 
 	w->changingSize = TRUE;
 	gtk_window_resize(w->window, winWidth, winHeight);
-	// gtk_window_resize may be asynchronous. Wait for the size-allocate event.
-	while (w->changingSize)
+	// gtk_window_resize() is asynchronous. Run the event loop manually.
+	while (gtk_events_pending())
 		if (!uiMainStep(1))
 			break;
+
+	// Hidden windows do not trigger the "size-allocate.
+	// TODO log failure for visible windows.
+	w->changingSize = FALSE;
 }
 
 int uiWindowFullscreen(uiWindow *w)

--- a/unix/window.c
+++ b/unix/window.c
@@ -362,6 +362,11 @@ uiWindow *uiNewWindow(const char *title, int width, int height, int hasMenubar)
 	w->container = GTK_CONTAINER(w->widget);
 	w->window = GTK_WINDOW(w->widget);
 
+	w->cachedPosX = 0;
+	w->cachedPosY = 0;
+	w->cachedWidth = width;
+	w->cachedHeight = height;
+
 	gtk_window_set_title(w->window, title);
 	gtk_window_resize(w->window, width, height);
 


### PR DESCRIPTION
This sadly got a lot bigger than initially anticipated but much of this code is interdependent, hence all of this at once: 

- Add unit tests for uiWindow
- Document uiWindowMargined default to be `FALSE`

Fixes for unix:
- Fix uiWindowContentSize upon window creation, see #252
- Make uiWindowSetPosition non blocking when hidden
- Make uiWindowSetContentSize non blocking when hidden
- Fix uiWindowSetContentSize for margined windows

`uiWindowContentSize` now uses  `gtk_window_get_size` and `gtk_window_resize` instead of trying to do some magic calculations on the inner container. According to the docs gtk already does a best effort calculation to report the size sans window decorations. The prior, inner container size code does not work on hidden windows and margined windows anyways and does not add anything on all systems I tested (i3wm and weston) apart from code, confusion, bugs and brittleness, hence the removal.

It is unclear to me if there was ever a good reason for doing these calculations. I could not find any documentation in the code or git log. All code related to window sizing is a best effort on all Unix systems anyways as the [gtk3 docs](https://docs.gtk.org/gtk3/method.Window.get_size.html) state everywhere. I did not notice any regressions by removing all the window size calculations.