### PR TITLE
darwin: Fix Darwin builds by removing `soversion`.

### DIFF
--- a/darwin/meson.build
+++ b/darwin/meson.build
@@ -60,6 +60,5 @@ libui_deps += [
 		modules: ['Foundation', 'AppKit'],
 		required: true),
 ]
-libui_soversion = 'A'
 # the / is required by some older versions of OS X
 libui_rpath = '@executable_path/'

--- a/meson.build
+++ b/meson.build
@@ -145,7 +145,6 @@ libui_libui_link_args = []
 
 libui_sources = []
 libui_deps = []
-libui_soversion = ''
 libui_rpath = ''
 subdir('common')
 if libui_OS == 'windows'
@@ -168,9 +167,7 @@ libui_libui = library('ui', libui_sources,
 	c_args: ['-Dlibui_EXPORTS'],
 	cpp_args: ['-Dlibui_EXPORTS'],
 	objc_args: ['-Dlibui_EXPORTS'],
-	link_args: libui_libui_link_args,
-	soversion: libui_soversion,
-	darwin_versions: [])		# TODO
+	link_args: libui_libui_link_args)
 install_headers('ui.h')
 
 # TODO when the API is stable enough to be versioned, create a pkg-config file (https://mesonbuild.com/Pkgconfig-module.html) and a declare_dependency() section too

--- a/unix/meson.build
+++ b/unix/meson.build
@@ -58,5 +58,4 @@ libui_deps += [
 	meson.get_compiler('c').find_library('dl',
 		required: false),
 ]
-libui_soversion = '0'
 libui_rpath = '$ORIGIN'


### PR DESCRIPTION
Meson 1.3.0 does not accept 'A' as the soversion anymore which breaks Darwin shared library builds.
Remove soversion versioning from all platforms as tagged API versions are lacking from the library at the moment anyways.

Fixes #258 (and our CI runners for macOS)