### PR TITLE
fix uiDrawMatrixScale on Linux and macOS

### DIFF
--- a/common/matrix.c
+++ b/common/matrix.c
@@ -31,12 +31,6 @@ void uiprivFallbackSkew(uiDrawMatrix *m, double x, double y, double xamount, dou
 	uiDrawMatrixMultiply(m, &n);
 }
 
-void uiprivScaleCenter(double xCenter, double yCenter, double *x, double *y)
-{
-	*x = xCenter - (*x * xCenter);
-	*y = yCenter - (*y * yCenter);
-}
-
 // the basic algorithm is from cairo
 // but it's the same algorithm as the transform point, just without M31 and M32 taken into account, so let's just do that instead
 void uiprivFallbackTransformSize(uiDrawMatrix *m, double *x, double *y)

--- a/common/uipriv.h
+++ b/common/uipriv.h
@@ -56,7 +56,6 @@ extern int uiprivFromScancode(uintptr_t, uiAreaKeyEvent *);
 
 // matrix.c
 extern void uiprivFallbackSkew(uiDrawMatrix *, double, double, double, double);
-extern void uiprivScaleCenter(double, double, double *, double *);
 extern void uiprivFallbackTransformSize(uiDrawMatrix *, double *, double *);
 
 // OS-specific text.* files

--- a/darwin/draw.m
+++ b/darwin/draw.m
@@ -325,35 +325,37 @@ static void c2m(CGAffineTransform *c, uiDrawMatrix *m)
 void uiDrawMatrixTranslate(uiDrawMatrix *m, double x, double y)
 {
 	CGAffineTransform c;
+	CGAffineTransform tmp;
 
 	m2c(m, &c);
-	c = CGAffineTransformTranslate(c, x, y);
+	tmp = CGAffineTransformMakeTranslation(x, y);
+	c = CGAffineTransformConcat(c, tmp);
 	c2m(&c, m);
 }
 
 void uiDrawMatrixScale(uiDrawMatrix *m, double xCenter, double yCenter, double x, double y)
 {
 	CGAffineTransform c;
-	double xt, yt;
+	CGAffineTransform tmp;
 
 	m2c(m, &c);
-	xt = x;
-	yt = y;
-	uiprivScaleCenter(xCenter, yCenter, &xt, &yt);
-	c = CGAffineTransformTranslate(c, xt, yt);
-	c = CGAffineTransformScale(c, x, y);
-	c = CGAffineTransformTranslate(c, -xt, -yt);
+	tmp = CGAffineTransformMakeTranslation(xCenter, yCenter);
+	tmp = CGAffineTransformScale(tmp, x, y);
+	tmp = CGAffineTransformTranslate(tmp, -xCenter, -yCenter);
+	c = CGAffineTransformConcat(c, tmp);
 	c2m(&c, m);
 }
 
 void uiDrawMatrixRotate(uiDrawMatrix *m, double x, double y, double amount)
 {
 	CGAffineTransform c;
+	CGAffineTransform tmp;
 
 	m2c(m, &c);
-	c = CGAffineTransformTranslate(c, x, y);
-	c = CGAffineTransformRotate(c, amount);
-	c = CGAffineTransformTranslate(c, -x, -y);
+	tmp = CGAffineTransformMakeTranslation(x, y);
+	tmp = CGAffineTransformRotate(tmp, amount);
+	tmp = CGAffineTransformTranslate(tmp, -x, -y);
+	c = CGAffineTransformConcat(c, tmp);
 	c2m(&c, m);
 }
 

--- a/test/unit/drawmatrix.c
+++ b/test/unit/drawmatrix.c
@@ -24,10 +24,10 @@ static int expectDoubleEqual(double a, double b, const char* error_prefix)
 	int equal = compareDouble(a, b, EPSILON);
 	if (!equal) {
 		if (error_prefix == NULL)
-	        cm_print_error("%f != %f\n", a, b);
+			cm_print_error("%f != %f\n", a, b);
 		else
-	        cm_print_error("%s%f != %f\n", error_prefix, a, b);
-    }
+			cm_print_error("%s%f != %f\n", error_prefix, a, b);
+	}
 	return equal;
 }
 

--- a/test/unit/drawmatrix.c
+++ b/test/unit/drawmatrix.c
@@ -19,14 +19,16 @@ static int compareDouble(double a, double b, double epsilon)
 void cm_print_error(const char * const format, ...);
 
 // Check if a == b without aborting the test.
-static int expectDoubleEqual(double a, double b, const char* error_prefix)
+static int expectDoubleEqual(double a, double b, int first_error, const char* error_prefix)
 {
+	// Function only used by assertMatrixEqual() macro below right now.
+	const char* func_prefix = first_error ? "(assertMatrixEqual)\n" : "";
 	int equal = compareDouble(a, b, EPSILON);
 	if (!equal) {
 		if (error_prefix == NULL)
-			cm_print_error("%f != %f\n", a, b);
+			cm_print_error("%s%f != %f\n", func_prefix, a, b);
 		else
-			cm_print_error("%s%f != %f\n", error_prefix, a, b);
+			cm_print_error("%s%s%f != %f\n", func_prefix, error_prefix, a, b);
 	}
 	return equal;
 }
@@ -39,12 +41,12 @@ static int expectDoubleEqual(double a, double b, const char* error_prefix)
 static void _assertMatrixEqual(uiDrawMatrix *a, uiDrawMatrix *b, const char * const file, const int line)
 {
 	int equal = 1;
-	equal &= expectDoubleEqual(a->M11, b->M11, "M11: ");
-	equal &= expectDoubleEqual(a->M12, b->M12, "M12: ");
-	equal &= expectDoubleEqual(a->M21, b->M21, "M21: ");
-	equal &= expectDoubleEqual(a->M22, b->M22, "M22: ");
-	equal &= expectDoubleEqual(a->M31, b->M31, "M31: ");
-	equal &= expectDoubleEqual(a->M32, b->M32, "M32: ");
+	equal &= expectDoubleEqual(a->M11, b->M11, equal, "M11: ");
+	equal &= expectDoubleEqual(a->M12, b->M12, equal, "M12: ");
+	equal &= expectDoubleEqual(a->M21, b->M21, equal, "M21: ");
+	equal &= expectDoubleEqual(a->M22, b->M22, equal, "M22: ");
+	equal &= expectDoubleEqual(a->M31, b->M31, equal, "M31: ");
+	equal &= expectDoubleEqual(a->M32, b->M32, equal, "M32: ");
 	if (!equal)
 		_fail(file, line);
 }

--- a/test/unit/drawmatrix.c
+++ b/test/unit/drawmatrix.c
@@ -1,0 +1,215 @@
+#include "unit.h"
+
+#ifndef ABS
+#define ABS(a) ((a) >= 0 ? (a) : -(a))
+#endif
+#ifndef MAX
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
+#define EPSILON 0.00001
+
+static int compareDouble(double a, double b, double epsilon)
+{
+	double diff = ABS(a - b);
+	double eps_scale = MAX(1.0, MAX(ABS(a), ABS(b)));
+	return diff <= epsilon * eps_scale;
+}
+
+// It's not defined in cmocka.h but exists in cmocka.c
+void cm_print_error(const char * const format, ...);
+
+// Check if a == b without aborting the test.
+static int expectDoubleEqual(double a, double b, const char* error_prefix)
+{
+	int equal = compareDouble(a, b, EPSILON);
+	if (!equal) {
+		if (error_prefix == NULL)
+	        cm_print_error("%f != %f\n", a, b);
+		else
+	        cm_print_error("%s%f != %f\n", error_prefix, a, b);
+    }
+	return equal;
+}
+
+// Assertion for uiDrawMatrix.
+// It works in the same way as the assert_* variants of cmocka.
+#define assertMatrixEqual(a, b) \
+	_assertMatrixEqual((uiDrawMatrix*)a, (uiDrawMatrix*)b, __FILE__, __LINE__)
+
+static void _assertMatrixEqual(uiDrawMatrix *a, uiDrawMatrix *b, const char * const file, const int line)
+{
+	int equal = 1;
+	equal &= expectDoubleEqual(a->M11, b->M11, "M11: ");
+	equal &= expectDoubleEqual(a->M12, b->M12, "M12: ");
+	equal &= expectDoubleEqual(a->M21, b->M21, "M21: ");
+	equal &= expectDoubleEqual(a->M22, b->M22, "M22: ");
+	equal &= expectDoubleEqual(a->M31, b->M31, "M31: ");
+	equal &= expectDoubleEqual(a->M32, b->M32, "M32: ");
+	if (!equal)
+		_fail(file, line);
+}
+
+static void drawMatrixIdentity(void **state)
+{
+	uiDrawMatrix *m = *state;
+	uiDrawMatrix expected = {
+		1.0, 0.0,
+		0.0, 1.0,
+		0.0, 0.0
+	};
+
+	assertMatrixEqual(&expected, m);
+}
+
+static void drawMatrixTranslate(void **state)
+{
+	uiDrawMatrix *m = *state;
+	double tx = 0.5;
+	double ty = 0.25;
+	uiDrawMatrixTranslate(m, tx, ty);
+
+	uiDrawMatrix expected = {
+		1.0, 0.0,
+		0.0, 1.0,
+		tx, ty
+	};
+
+	assertMatrixEqual(&expected, m);
+}
+
+static void drawMatrixScale(void **state)
+{
+	uiDrawMatrix *m = *state;
+	double cx = 0.25;
+	double cy = 0.125;
+	double sx = 0.5;
+	double sy = 0.25;
+	uiDrawMatrixScale(m, cx, cy, sx, sy);
+
+	uiDrawMatrix expected = {
+		sx, 0.0,
+		0.0, sy,
+		-cx * sx + cx,
+		-cy * sy + cy
+	};
+
+	assertMatrixEqual(&expected, m);
+}
+
+#define THETA uiPi / 6
+#define COS 1.73205080757 / 2
+#define SIN 0.5
+
+static void drawMatrixRotate(void **state)
+{
+	uiDrawMatrix *m = *state;
+	double cx = 0.25;
+	double cy = 0.125;
+	uiDrawMatrixRotate(m, cx, cy, THETA);
+
+	uiDrawMatrix expected = {
+		COS, SIN,
+		-SIN, COS,
+		-cx * COS + cy * SIN + cx,
+		-cx * SIN - cy * COS + cy
+	};
+
+	assertMatrixEqual(&expected, m);
+}
+
+static void drawMatrixTRS(void **state)
+{
+	uiDrawMatrix *m = *state;
+
+	double tx = 0.5;
+	double ty = 0.25;
+	double sx = 0.3;
+	double sy = 0.1;
+	uiDrawMatrixTranslate(m, tx, ty);
+	uiDrawMatrixRotate(m, tx, ty, THETA);
+	uiDrawMatrixScale(m, tx, ty, sx, sy);
+
+	uiDrawMatrix expected = {
+		COS * sx, SIN * sy,
+		-SIN * sx, COS * sy,
+		tx, ty,
+	};
+
+	assertMatrixEqual(&expected, m);
+}
+
+static void drawMatrixMultiply(void **state)
+{
+	// Test the same transform as drawMatrixTRS with uiDrawMatrixMultiply
+	uiDrawMatrix *m = *state;
+
+	uiDrawMatrix t;
+	double tx = 0.5;
+	double ty = 0.25;
+	uiDrawMatrixSetIdentity(&t);
+	uiDrawMatrixTranslate(&t, tx, ty);
+
+	uiDrawMatrix r;
+	uiDrawMatrixSetIdentity(&r);
+	uiDrawMatrixRotate(&r, tx, ty, THETA);
+
+	uiDrawMatrix s;
+	double sx = 0.3;
+	double sy = 0.1;
+	uiDrawMatrixSetIdentity(&s);
+	uiDrawMatrixScale(&s, tx, ty, sx, sy);
+
+	uiDrawMatrixMultiply(m, &t);
+	uiDrawMatrixMultiply(m, &r);
+	uiDrawMatrixMultiply(m, &s);
+
+	uiDrawMatrix expected = {
+		COS * sx, SIN * sy,
+		-SIN * sx, COS * sy,
+		tx, ty,
+	};
+
+	assertMatrixEqual(&expected, m);
+}
+
+static int drawMatrixTestsSetup(void **state)
+{
+	*state = malloc(sizeof(uiDrawMatrix));
+	assert_non_null(*state);
+	return 0;
+}
+
+static int drawMatrixTestsTeardown(void **state)
+{
+	free(*state);
+	return 0;
+}
+
+int drawMatrixTestSetup(void **state)
+{
+	uiDrawMatrix *m = *state;
+	uiDrawMatrixSetIdentity(m);
+	return 0;
+}
+
+int drawMatrixTestTeardown(void **state)
+{
+	return 0;
+}
+
+#define drawMatrixUnitTest(f) cmocka_unit_test_setup_teardown((f), \
+		drawMatrixTestSetup, drawMatrixTestTeardown)
+
+int drawMatrixRunUnitTests(void)
+{
+	const struct CMUnitTest tests[] = {
+		drawMatrixUnitTest(drawMatrixIdentity),
+		drawMatrixUnitTest(drawMatrixTranslate),
+		drawMatrixUnitTest(drawMatrixScale),
+		drawMatrixUnitTest(drawMatrixRotate),
+		drawMatrixUnitTest(drawMatrixTRS),
+		drawMatrixUnitTest(drawMatrixMultiply),
+	};
+
+	return cmocka_run_group_tests_name("uiDrawMatrix", tests, drawMatrixTestsSetup, drawMatrixTestsTeardown);
+}

--- a/test/unit/main.c
+++ b/test/unit/main.c
@@ -67,6 +67,7 @@ int main(void)
 		{ radioButtonsRunUnitTests },
 		{ entryRunUnitTests },
 		{ progressBarRunUnitTests },
+		{ drawMatrixRunUnitTests },
 	};
 
 	for (i = 0; i < sizeof(unitTests)/sizeof(*unitTests); ++i) {

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -14,6 +14,7 @@ libui_unit_sources = [
         'entry.c',
         'menu.c',
         'progressbar.c',
+	'drawmatrix.c',
 ]
 
 if libui_OS == 'windows'

--- a/test/unit/unit.h
+++ b/test/unit/unit.h
@@ -24,6 +24,7 @@ int radioButtonsRunUnitTests(void);
 int entryRunUnitTests(void);
 int menuRunUnitTests(void);
 int progressBarRunUnitTests(void);
+int drawMatrixRunUnitTests(void);
 
 /**
  * Helper for general setup/teardown of controls embedded in a window.

--- a/unix/drawmatrix.c
+++ b/unix/drawmatrix.c
@@ -31,35 +31,37 @@ static void c2m(cairo_matrix_t *c, uiDrawMatrix *m)
 void uiDrawMatrixTranslate(uiDrawMatrix *m, double x, double y)
 {
 	cairo_matrix_t c;
+	cairo_matrix_t tmp;
 
 	m2c(m, &c);
-	cairo_matrix_translate(&c, x, y);
+	cairo_matrix_init_translate(&tmp, x, y);
+	cairo_matrix_multiply(&c, &c, &tmp);
 	c2m(&c, m);
 }
 
 void uiDrawMatrixScale(uiDrawMatrix *m, double xCenter, double yCenter, double x, double y)
 {
 	cairo_matrix_t c;
-	double xt, yt;
+	cairo_matrix_t tmp;
 
 	m2c(m, &c);
-	xt = x;
-	yt = y;
-	uiprivScaleCenter(xCenter, yCenter, &xt, &yt);
-	cairo_matrix_translate(&c, xt, yt);
-	cairo_matrix_scale(&c, x, y);
-	cairo_matrix_translate(&c, -xt, -yt);
+	cairo_matrix_init_translate(&tmp, xCenter, yCenter);
+	cairo_matrix_scale(&tmp, x, y);
+	cairo_matrix_translate(&tmp, -xCenter, -yCenter);
+	cairo_matrix_multiply(&c, &c, &tmp);
 	c2m(&c, m);
 }
 
 void uiDrawMatrixRotate(uiDrawMatrix *m, double x, double y, double amount)
 {
 	cairo_matrix_t c;
+	cairo_matrix_t tmp;
 
 	m2c(m, &c);
-	cairo_matrix_translate(&c, x, y);
-	cairo_matrix_rotate(&c, amount);
-	cairo_matrix_translate(&c, -x, -y);
+	cairo_matrix_init_translate(&tmp, x, y);
+	cairo_matrix_rotate(&tmp, amount);
+	cairo_matrix_translate(&tmp, -x, -y);
+	cairo_matrix_multiply(&c, &c, &tmp);
 	c2m(&c, m);
 }
 


### PR DESCRIPTION
Related to https://github.com/andlabs/libui/issues/331 and https://github.com/libui-ng/libui-ng/pull/54.

This PR removes `uiprivScaleCenter` to fix the scaling issue.
That's a method proposed in the old issue page.
(maybe it's the way cody used in the old PR?)

You can see the same result in the tester app on all platforms.
![windows](https://github.com/libui-ng/libui-ng/assets/69258547/7ec055f3-a961-4873-9669-57aa8994a035)
![linux_fixed](https://github.com/libui-ng/libui-ng/assets/69258547/7c285b0c-c8a6-42dc-ab64-01db175ec01e)
![mac_fixed](https://github.com/libui-ng/libui-ng/assets/69258547/d030cd0b-75e5-401b-ae69-b3452c09aeb3)

And here is another example.
I made a function to draw ovals by scaling circles.

```c
uiDrawSave(context);

uiDrawMatrixSetIdentity(&m);
uiDrawMatrixScale(&m, x, y, sx, sy);
uiDrawTransform(context, &m);

path = uiDrawNewPath(uiDrawFillModeWinding);
uiDrawPathNewFigureWithArc(path, x, y, radius, 0, uiPi * 2, 0);
uiDrawPathEnd(path);

uiDrawFill(context, path, &brush);
uiDrawFreePath(path);

uiDrawRestore(context);
```

It moves circles vertically even if I fix the center points of circles.

https://github.com/libui-ng/libui-ng/assets/69258547/06419a46-52a9-41c6-ab3e-755985559be2

My PR fixes the weird behavior.

https://github.com/libui-ng/libui-ng/assets/69258547/89416ca8-6cd2-46f5-a4c7-c7ce5eaa8796

I also tried to wrap `uiArea` with `uiGrid` just to be sure.
(That's a workaround proposed by msink in the old PR.)
But it did nothing on my machines.
```c
uiGridAppend(grid, uiControl(area), 0, 0, 1, 1, 1, uiAlignFill, 1, uiAlignFill);
```