### PR TITLE
Allow dialogs without a parent window

### DIFF
--- a/darwin/stddialogs.m
+++ b/darwin/stddialogs.m
@@ -5,7 +5,7 @@
 // LONGTERM explicitly document this works as we want
 // LONGTERM note that font and color buttons also do this
 
-#define windowWindow(w) ((NSWindow *) uiControlHandle(uiControl(w)))
+#define windowWindow(w) ((w) ? (NSWindow *) uiControlHandle(uiControl(w)) : nil)
 
 // source of code modal logic: http://stackoverflow.com/questions/604768/wait-for-nsalert-beginsheetmodalforwindow
 

--- a/unix/stddialogs.c
+++ b/unix/stddialogs.c
@@ -4,7 +4,7 @@
 // LONGTERM figure out why, and describe, that this is the desired behavior
 // LONGTERM also point out that font and color buttons also work like this
 
-#define windowWindow(w) (GTK_WINDOW(uiControlHandle(uiControl(w))))
+#define windowWindow(w) ((w) ? (GTK_WINDOW(uiControlHandle(uiControl(w)))) : NULL)
 
 static char *filedialog(GtkWindow *parent, GtkFileChooserAction mode, const gchar *confirm)
 {

--- a/windows/stddialogs.cpp
+++ b/windows/stddialogs.cpp
@@ -14,7 +14,7 @@
 // - when a dialog is active, tab navigation in other windows stops working
 // - when adding uiOpenFolder(), use IFileDialog as well - https://msdn.microsoft.com/en-us/library/windows/desktop/bb762115%28v=vs.85%29.aspx
 
-#define windowHWND(w) ((HWND) uiControlHandle(uiControl(w)))
+#define windowHWND(w) (w ? (HWND)uiControlHandle(uiControl(w)) : NULL)
 
 char *commonItemDialog(HWND parent, REFCLSID clsid, REFIID iid, FILEOPENDIALOGOPTIONS optsadd)
 {


### PR DESCRIPTION
This is revival of https://github.com/libui-ng/libui-ng/pull/50.

I added support for macOS.

And tested the following code on Windows10, Ubuntu20.04, and macOS 10.15.
```c
int main(void)
{
    uiInitOptions options;
    const char *err;

    memset(&options, 0, sizeof (uiInitOptions));
    err = uiInit(&options);
    if (err != NULL) {
        fprintf(stderr, "error initializing libui: %s", err);
        uiFreeInitError(err);
        return 1;
    }

    uiMsgBox(NULL, "NULL Parent Test", "Dialogs wihtout a parent window.");
}
```

This feature is useful because you can use dialogs before creating the main window.
For example, you can close your app with an error dialog before the main loop.
I hope it will be merged soon.