### PR TITLE
windows: Fix separator orientation

### DIFF
--- a/windows/separator.cpp
+++ b/windows/separator.cpp
@@ -64,7 +64,7 @@ uiSeparator *uiNewVerticalSeparator(void)
 
 	s->hwnd = uiWindowsEnsureCreateControlHWND(0,
 		L"static", L"",
-		SS_ETCHEDHORZ,
+		SS_ETCHEDVERT,
 		hInstance, NULL,
 		TRUE);
 	s->vertical = TRUE;


### PR DESCRIPTION
Hello.

I was thinking about how I can contribute to the project easily and without any difficulty, and I came up with the idea of having ChatGPT review libui-ng.

According to ChatGPT, it could be wrong here.

> In the `uiSeparator *uiNewVerticalSeparator(void)` function, despite creating a new separator that is vertical, `SS_ETCHEDHORZ` is being passed as an argument. This constant represents a horizontal line style. Therefore, `SS_ETCHEDVERT` should be used here instead.

- https://learn.microsoft.com/en-us/windows/win32/controls/static-control-styles

However, I am not sure. It is possible that the code is intentional. If there is no problem, please close it.