### PR TITLE
Update macOS runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,8 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-latest (macos-10.15), macos-11
-        os: [macos-11]
+        os: [macos-latest]
         libtype: [static, shared]
         # debug, debugoptimized, release
         buildtype: [debug]


### PR DESCRIPTION
Github Actions will drop `macos-11` support on 6/28/2024.

- [About GitHub-hosted runners - GitHub Docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
- [GitHub Actions: macOS 14 (Sonoma) is now available - The GitHub Blog](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/)

So, we have to use a newer version of macOS runners.