### PR TITLE
Rename static library suffix for Windows MSVC

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -125,19 +125,9 @@ add_project_arguments(libui_project_compile_args,
 add_project_link_arguments(libui_project_link_args,
 	language: ['c', 'cpp', 'objc'])
 
-if libui_OS == 'windows'
-	if libui_MSVC
-		static_lib_suffix = 'lib'
-	else
-		static_lib_suffix = 'a'
-	endif
-	shared_lib_suffix = 'dll'
-elif libui_OS == 'darwin'
-	static_lib_suffix = 'a'
-	shared_lib_suffix = 'dylib'
-else
-	static_lib_suffix = 'a'
-	shared_lib_suffix = 'so'
+libui_lib_suffix = []
+if libui_OS == 'windows' and libui_MSVC
+	libui_lib_suffix = 'lib'
 endif
 
 # TODO:

--- a/meson.build
+++ b/meson.build
@@ -125,6 +125,21 @@ add_project_arguments(libui_project_compile_args,
 add_project_link_arguments(libui_project_link_args,
 	language: ['c', 'cpp', 'objc'])
 
+if libui_OS == 'windows'
+	if libui_MSVC
+		static_lib_suffix = 'lib'
+	else
+		static_lib_suffix = 'a'
+	endif
+	shared_lib_suffix = 'dll'
+elif libui_OS == 'darwin'
+	static_lib_suffix = 'a'
+	shared_lib_suffix = 'dylib'
+else
+	static_lib_suffix = 'a'
+	shared_lib_suffix = 'so'
+endif
+
 # TODO:
 # meson determins whether -Wl,--no-undefined is provided via
 # built-in option b_lundef, and it's true by default, which is what
@@ -162,6 +177,7 @@ libui_libui = library('ui', libui_sources,
 	build_rpath: libui_rpath,
 	install_rpath: libui_rpath,
 	name_prefix: 'lib',		# always call it libui, even in Windows DLLs
+	name_suffix: (libui_mode == 'static') ? static_lib_suffix : shared_lib_suffix,
 	install: true,
 	gnu_symbol_visibility: 'hidden',
 	c_args: ['-Dlibui_EXPORTS'],


### PR DESCRIPTION
Change the static library extension to .lib for MSVC.

See #290