### PR TITLE
The first window displayed center, second and subsequent displayed ca…

### DIFF
--- a/darwin/window.m
+++ b/darwin/window.m
@@ -170,7 +170,15 @@ static int uiWindowVisible(uiControl *c)
 
 static void uiWindowShow(uiControl *c)
 {
+        NSWindow *front = [uiprivNSApp() mainWindow];
 	uiWindow *w = uiWindow(c);
+
+	if (front) {
+	  NSPoint topLeft = [front cascadeTopLeftFromPoint:NSZeroPoint];
+	  [w->window setFrameTopLeftPoint: topLeft];
+	} else {
+	  [w->window center];
+	}
 
 	[w->window makeKeyAndOrderFront:w->window];
 }


### PR DESCRIPTION
Change Initial position of uiWindow on macOS.

1. The First Window is displayed at center.
2. Second and subsequent are displayed cascaded.

Because (single)App and DocumentApp templates of SwiftUI do like this.