### PR TITLE
Fix timer ID mismatch in Windows table indeterminate progress bar

### DIFF
--- a/windows/table.cpp
+++ b/windows/table.cpp
@@ -226,7 +226,7 @@ int uiprivTableProgress(uiTable *t, int item, int subitem, int modelColumn, LONG
 		if (SetTimer(t->hwnd, (UINT_PTR) t, 30, NULL) == 0)
 			logLastError(L"SetTimer()");
 	if (stopTimer)
-		if (KillTimer(t->hwnd, (UINT_PTR) (&t)) == 0)
+		if (KillTimer(t->hwnd, (UINT_PTR) t) == 0)
 			logLastError(L"KillTimer()");
 
 	return progress;


### PR DESCRIPTION
Hi there!

I was having trouble with a Table that occurs only on Windows, so I had `gdb` and AI (Cline + ChatGPT/Claude) look into it and made the following fixes. The pull request instructions were written by Cline. Thank you.

---

## Problem Description

A timer ID mismatch was occurring in the Windows table implementation during indeterminate progress bar (progress value -1) animation processing.

## Issue Details

- `SetTimer()` and `KillTimer()` were using different timer IDs
- `SetTimer()`: Used `(UINT_PTR) t`
- `KillTimer()`: Used `(UINT_PTR) (&t)` (incorrect)
- This caused `KillTimer()` to fail, resulting in timer resource leaks

## Fix Applied

Modified the `KillTimer()` call in the `uiprivTableProgress` function in `windows/table.cpp`:

```cpp
// Before
if (KillTimer(t->hwnd, (UINT_PTR) (&t)) == 0)

// After  
if (KillTimer(t->hwnd, (UINT_PTR) t) == 0)
```
