### PR TITLE
windows: render COLR color fonts (color emoji) instead of monochrome

### DIFF
--- a/windows/drawtext.cpp
+++ b/windows/drawtext.cpp
@@ -2,6 +2,9 @@
 #include "uipriv_windows.hpp"
 #include "draw.hpp"
 #include "attrstr.hpp"
+// IDWriteFactory2 / TranslateColorGlyphRun / DWRITE_COLOR_GLYPH_RUN / DWRITE_E_NOCOLOR
+// (color-emoji rendering; Windows 8.1+). dwrite_2.h transitively includes dwrite.h.
+#include <dwrite_2.h>
 
 // TODO verify our renderer is correct, especially with regards to snapping
 
@@ -234,6 +237,10 @@ class textRenderer : public IDWriteTextRenderer {
 	ID2D1RenderTarget *rt;
 	BOOL snap;
 	ID2D1SolidColorBrush *black;
+	// Cached QI to the v2 factory for color-emoji (COLR/CPAL) decomposition.
+	// May legitimately be NULL on pre-Windows-8.1 systems; then we fall back to
+	// the monochrome glyph-run draw. See #344.
+	IDWriteFactory2 *dwfactory2;
 public:
 	textRenderer(ID2D1RenderTarget *rt, BOOL snap, ID2D1SolidColorBrush *black)
 	{
@@ -241,6 +248,9 @@ public:
 		this->rt = rt;
 		this->snap = snap;
 		this->black = black;
+		// QI once; on failure dwfactory2 stays NULL and we use the monochrome path.
+		this->dwfactory2 = NULL;
+		dwfactory->QueryInterface(__uuidof (IDWriteFactory2), (void **) (&(this->dwfactory2)));
 	}
 
 	// IUnknown
@@ -269,6 +279,8 @@ public:
 	{
 		this->refcount--;
 		if (this->refcount == 0) {
+			if (this->dwfactory2 != NULL)
+				this->dwfactory2->Release();
 			delete this;
 			return 0;
 		}
@@ -332,11 +344,91 @@ public:
 			brush = this->black;
 			brush->AddRef();
 		}
-		this->rt->DrawGlyphRun(
-			baseline,
-			glyphRun,
-			brush,
-			measuringMode);
+
+		// Color-emoji (COLR/CPAL) support. `brush` is the resolved foreground/text
+		// brush; reuse it for layers that want the current color. Decompose the run
+		// into color layers via IDWriteFactory2::TranslateColorGlyphRun and draw each
+		// one; on DWRITE_E_NOCOLOR / E_NOTIMPL / no v2 factory, fall back byte-for-byte
+		// to the original monochrome draw so normal text never regresses. See #344.
+		HRESULT hr = DWRITE_E_NOCOLOR;
+		IDWriteColorGlyphRunEnumerator *colorLayers = NULL;
+
+		if (this->dwfactory2 != NULL)
+			hr = this->dwfactory2->TranslateColorGlyphRun(
+				baselineOriginX,
+				baselineOriginY,
+				glyphRun,
+				glyphRunDescription,	// optional; may be NULL
+				measuringMode,
+				NULL,			// worldToDeviceTransform: NULL = identity; rt owns the transform
+				0,			// colorPaletteIndex 0 = font's default palette
+				&colorLayers);
+
+		if (this->dwfactory2 == NULL || hr == DWRITE_E_NOCOLOR || hr == E_NOTIMPL) {
+			// Not a color font (or color API unavailable): original monochrome draw.
+			this->rt->DrawGlyphRun(
+				baseline,
+				glyphRun,
+				brush,
+				measuringMode);
+		} else if (FAILED(hr)) {
+			// Genuine failure: clean up and propagate.
+			brush->Release();
+			return logHRESULT(L"error translating color glyph run", hr);
+		} else {
+			// Color run: walk each layer and draw it.
+			for (;;) {
+				BOOL haveRun = FALSE;
+				const DWRITE_COLOR_GLYPH_RUN *colorRun = NULL;
+				ID2D1Brush *layerBrush;
+				ID2D1SolidColorBrush *tempBrush = NULL;
+				D2D1_POINT_2F layerBaseline;
+
+				hr = colorLayers->MoveNext(&haveRun);
+				if (hr != S_OK) {
+					colorLayers->Release();
+					brush->Release();
+					return logHRESULT(L"error advancing color glyph run enumerator", hr);
+				}
+				if (!haveRun)
+					break;
+
+				hr = colorLayers->GetCurrentRun(&colorRun);
+				if (hr != S_OK || colorRun == NULL) {
+					colorLayers->Release();
+					brush->Release();
+					return logHRESULT(L"error getting current color glyph run", hr != S_OK ? hr : E_UNEXPECTED);
+				}
+
+				if (colorRun->paletteIndex == 0xFFFF) {
+					// This layer uses the current/foreground text color.
+					layerBrush = brush;
+				} else {
+					// This layer has its own palette color. runColor is a
+					// DWRITE_COLOR_F == D2D1_COLOR_F, usable directly.
+					hr = this->rt->CreateSolidColorBrush(colorRun->runColor, &tempBrush);
+					if (hr != S_OK) {
+						colorLayers->Release();
+						brush->Release();
+						return logHRESULT(L"error creating color glyph layer brush", hr);
+					}
+					layerBrush = tempBrush;
+				}
+
+				layerBaseline.x = colorRun->baselineOriginX;
+				layerBaseline.y = colorRun->baselineOriginY;
+				this->rt->DrawGlyphRun(
+					layerBaseline,
+					&colorRun->glyphRun,	// glyphRun is a by-value member; take its address
+					layerBrush,
+					measuringMode);
+
+				if (tempBrush != NULL)
+					tempBrush->Release();
+			}
+			colorLayers->Release();
+		}
+
 		brush->Release();
 		return S_OK;
 	}


### PR DESCRIPTION
## Problem

On Windows, color emoji (e.g. Segoe UI Emoji) render as flat monochrome outlines instead of in color; macOS (CoreText) renders them correctly. This is the color-emoji half of #344.

## Cause

The custom `IDWriteTextRenderer` in `windows/drawtext.cpp` draws every glyph run with a single solid brush via `ID2D1RenderTarget::DrawGlyphRun`, so color (COLR/CPAL) fonts are never decomposed — the layered color glyphs collapse to their monochrome fallback.

## Fix

In `DrawGlyphRun`, QueryInterface the existing `dwfactory` to `IDWriteFactory2` and use `TranslateColorGlyphRun` to split the run into its color layers, drawing each layer in its palette color (reusing the foreground brush for `paletteIndex == 0xFFFF`). On `DWRITE_E_NOCOLOR` / `E_NOTIMPL` / pre-8.1 systems (no `IDWriteFactory2`), it falls back byte-for-byte to the original monochrome draw, so non-color text is unaffected.

- `IDWriteFactory2` is QueryInterface'd once and cached on the renderer; released in `Release()`.
- The per-layer brushes and the color-run enumerator are released on all paths.

## Testing

Built with MSVC and verified by a downstream consumer (a PHP/FFI binding): color emoji now render in color on Windows, and normal text is unchanged. macOS/Linux are unaffected — the change is confined to `windows/drawtext.cpp`.

Note: #344 also mentions text background color not being applied on Windows; that is a separate issue and is **not** addressed here.
